### PR TITLE
V0.1

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -1,14 +1,24 @@
 Change log
 ==========
 
-[Unreleased]
-------------
+v0.1.0
+------
 
-Schema related fixes:
+Major changes:
+- ``Schema`` class removed. Any pydantic model can now be an output schema.
 
-- Better schema support for ``typing.Any``.
-- ``Schema`` no longer subclasses ``MSONable``. This improves the schema description
-  and fixes a number of bugs.
+Enhancements:
+
+- ``JobStore.get_output`` now resolves references in the output of other jobs.
+- ``JobStore.get_output``: ``which`` now supports specifying a specific job index.
+- Better support for circular and missing references in ``JobStore.get_output`` and
+  ``OutputReference.resolve``.
+- Update dependencies to use latest jsanitize features.
+
+Bug fixes:
+- Fixed issue with references in flow of flows (@davidwaroquiers, #18).
+- Makes now allows non-default parameters (fixes: #13).
+- Fix reference cache with multiple indexes.
 
 v0.0.2
 ------

--- a/docs/src/contributors.rst
+++ b/docs/src/contributors.rst
@@ -25,3 +25,21 @@ Berkeley National Laboratory.
    :width: 16
    :height: 16
    :alt: ORCID profile for 0000-0002-4486-3321
+
+
+Additional contributions provided by:
+
+| **David Waroquiers** |davidwaroquiers| |0000-0001-8943-9762|
+| Université Catholique de Louvain
+
+.. |davidwaroquiers| image:: https://cdnjs.cloudflare.com/ajax/libs/octicons/8.5.0/svg/mark-github.svg
+   :target: https://github.com/davidwaroquiers
+   :width: 16
+   :height: 16
+   :alt: GitHub commits from davidwaroquiers
+
+.. |0000-0001-8943-9762| image:: _static/orcid.svg
+   :target: https://orcid.org/0000-0001-8943-9762
+   :width: 16
+   :height: 16
+   :alt: ORCID profile for 0000-0001-8943-9762

--- a/examples/maker.py
+++ b/examples/maker.py
@@ -5,7 +5,7 @@ from jobflow import Flow, Maker, job, run_locally
 
 @dataclass
 class AddMaker(Maker):
-    name: str = "Add"
+    name: str = "add"
     c: int = 10
 
     @job

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-monty==2021.6.10
+monty==2021.7.8
 networkx==2.5.1
 pydash==5.0.0
 maggma==0.26.0

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -534,7 +534,7 @@ class Job(MSONable):
                 pass_manager_config(response.replace, self.config.manager_config)
 
         try:
-            output = jsanitize(response.output, strict=True, allow_bson=True)
+            output = jsanitize(response.output, strict=True, enum_values=True)
         except AttributeError:
             raise RuntimeError(
                 "Job output contained an object that is not MSONable and therefore "

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -584,13 +584,13 @@ class Job(MSONable):
         cache: Dict[str, Any] = {}
         resolved_args = find_and_resolve_references(
             self.function_args,
-            store=store,
+            store,
             cache=cache,
             on_missing=self.config.on_missing_references,
         )
         resolved_kwargs = find_and_resolve_references(
             self.function_kwargs,
-            store=store,
+            store,
             cache=cache,
             on_missing=self.config.on_missing_references,
         )

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -20,13 +20,9 @@ class Maker(MSONable):
     """
     Base maker (factory) class for constructing :obj:`Job` and :obj:`Flow` objects.
 
-    Note, this class is only an abstract implementation. To create a functioning Maker
-    subclass :obj:`Maker` and define the ``make`` method. See examples below.
-
-    Parameters
-    ----------
-    name
-        The name of jobs or flows created from this maker.
+    Note, this class is only an abstract implementation. To create a functioning Maker,
+    one should  subclass :obj:`Maker`, define the ``make`` method and add a name field
+    with a default value. See examples below.
 
     See Also
     --------
@@ -35,7 +31,9 @@ class Maker(MSONable):
     Examples
     --------
     Below we define a simple maker that generates a job to add two numbers. Next, we
-    make a job using the maker.
+    make a job using the maker. When creating a new maker it is essential to: 1)
+    Add a name field with a default value (this controls the name of jobs produced
+    by the maker) and 2) override the ``make`` method with a concrete implementation.
 
     >>> from dataclasses import dataclass
     >>> from jobflow import Maker, job
@@ -83,6 +81,7 @@ class Maker(MSONable):
     >>> from jobflow import Response
     >>> @dataclass
     ... class SquareThenAddMaker(Maker):
+    ...     name: str = "square then add"
     ...     add_maker: Maker = AddMaker()
     ...
     ...     @job
@@ -110,6 +109,7 @@ class Maker(MSONable):
     >>> from jobflow import Flow
     >>> @dataclass
     ... class DoubleAddMaker(Maker):
+    ...     name: str = "double add"
     ...     add_maker: Maker = AddMaker()
     ...
     ...     def make(self, a, b):
@@ -120,10 +120,13 @@ class Maker(MSONable):
     >>> double_add_job = maker.make(1, 2)
     """
 
-    name: str = "Maker"
-
     def make(self, *args, **kwargs) -> Union[jobflow.Flow, jobflow.Job]:
         """Make a job or a flow - must be overridden with a concrete implementation."""
+        raise NotImplementedError
+
+    @property
+    def name(self):
+        """Name of the Maker - must be overridden with a dataclass field."""
         raise NotImplementedError
 
     def update_kwargs(
@@ -165,6 +168,7 @@ class Maker(MSONable):
         >>> from jobflow import job, Maker
         >>> @dataclass
         ... class AddMaker(Maker):
+        ...     name: str = "add"
         ...     number: float = 10
         ...
         ...     @job
@@ -183,6 +187,7 @@ class Maker(MSONable):
         >>> from jobflow import Response
         >>> @dataclass
         ... class SquareThenAddMaker(Maker):
+        ...     name: str = "square then add"
         ...     add_maker: Maker = AddMaker()
         ...
         ...     @job

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -345,10 +345,9 @@ def resolve_references(
             cache[uuid] = {}
 
         if index is not None and index not in cache[uuid]:
-            try:
-                cache[uuid][index] = store.get_output(uuid, load=True)
-            except ValueError:
-                pass
+            cache[uuid][index] = store.get_output(
+                uuid, load=True, on_missing=on_missing
+            )
 
         for ref in ref_group:
             resolved_references[ref] = ref.resolve(

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -379,7 +379,7 @@ def find_and_get_references(arg: Any) -> Tuple[OutputReference, ...]:
         # argument is a primitive, we won't find a reference here
         return tuple()
 
-    arg = jsanitize(arg, strict=True)
+    arg = jsanitize(arg, strict=True, enum_values=True)
 
     # recursively find any reference classes
     locations = find_key_value(arg, "@class", "OutputReference")
@@ -432,7 +432,7 @@ def find_and_resolve_references(
         return arg
 
     # serialize the argument to a dictionary
-    encoded_arg = jsanitize(arg, strict=True)
+    encoded_arg = jsanitize(arg, strict=True, enum_values=True)
 
     # recursively find any reference classes
     locations = find_key_value(encoded_arg, "@class", "OutputReference")

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -109,7 +109,7 @@ class OutputReference(MSONable):
 
     def resolve(
         self,
-        store: Optional[jobflow.JobStore] = None,
+        store: Optional[jobflow.JobStore],
         cache: Optional[Dict[str, Any]] = None,
         on_missing: OnMissing = OnMissing.ERROR,
     ) -> Any:
@@ -118,6 +118,11 @@ class OutputReference(MSONable):
 
         This function will query the job store for the reference value and perform any
         attribute accesses/indexing.
+
+        .. Note::
+            When resolving multiple references simultaneously it is more efficient to
+            use :obj:`.resolve_references` as it will minimize the number of database
+            requests.
 
         Parameters
         ----------
@@ -141,45 +146,46 @@ class OutputReference(MSONable):
             The resolved reference if it can be found. If the reference cannot be found,
             the returned value will depend on the value of ``on_missing``.
         """
-        # when resolving multiple references simultaneously it is more efficient
-        # to use resolve_references as it will minimize the number of database requests
-        if store is None and cache is None and on_missing == OnMissing.ERROR:
-            raise ValueError("At least one of store and cache must be set.")
-
         if cache is None:
             cache = {}
 
-        if store and self.uuid not in cache:
+        if self.uuid not in cache:
+            cache[self.uuid] = {}
+
+        # get the latest index for the output
+        result = store.query_one({"uuid": self.uuid}, ["index"], sort={"index": -1})
+        index = None if result is None else result["index"]
+
+        if index is not None and index not in cache[self.uuid]:
             try:
-                cache[self.uuid] = store.get_output(self.uuid, which="last", load=True)
+                cache[self.uuid][index] = store.get_output(
+                    self.uuid, which="last", load=True
+                )
             except ValueError:
                 pass
 
-        if on_missing == OnMissing.ERROR and self.uuid not in cache:
+        if on_missing == OnMissing.ERROR and index not in cache[self.uuid]:
+            istr = f" ({index})" if index is not None else ""
             raise ValueError(
-                f"Could not resolve reference - {self.uuid} not in store or cache"
+                f"Could not resolve reference - {self.uuid}{istr} not in store or cache"
             )
+        elif on_missing == OnMissing.NONE and index not in cache[self.uuid]:
+            return None
+        elif on_missing == OnMissing.PASS and index not in cache[self.uuid]:
+            return self
 
-        try:
-            data = cache[self.uuid]
-        except KeyError:
-            # if we get to here, that means the reference cannot be resolved
-            if on_missing == OnMissing.NONE:
-                return None
-            else:
-                # only other option is OnMissing.PASS
-                return self
+        data = cache[self.uuid][index]
 
         # resolve nested references
         data = find_and_resolve_references(
-            data, store=store, cache=cache, on_missing=on_missing
+            data, store, cache=cache, on_missing=on_missing
         )
 
         # decode objects before attribute access
         data = MontyDecoder().process_decoded(data)
 
         # re-cache data in case other references need it
-        cache[self.uuid] = data
+        cache[self.uuid][index] = data
 
         for attr_type, attr in self.attributes:
             if attr_type == "i":
@@ -303,7 +309,7 @@ class OutputReference(MSONable):
 
 def resolve_references(
     references: Sequence[OutputReference],
-    store: Optional[jobflow.JobStore] = None,
+    store: jobflow.JobStore,
     cache: Optional[Dict[str, Any]] = None,
     on_missing: OnMissing = OnMissing.ERROR,
 ) -> Dict[OutputReference, Any]:
@@ -336,15 +342,23 @@ def resolve_references(
         cache = {}
 
     for uuid, ref_group in groupby(references, key=lambda x: x.uuid):
-        if uuid not in cache and store is not None:
+
+        # get latest index
+        result = store.query_one({"uuid": uuid}, ["index"], sort={"index": -1})
+        index = None if result is None else result["index"]
+
+        if uuid not in cache:
+            cache[uuid] = {}
+
+        if index is not None and index not in cache[uuid]:
             try:
-                cache[uuid] = store.get_output(uuid, load=True)
+                cache[uuid][index] = store.get_output(uuid, load=True)
             except ValueError:
                 pass
 
         for ref in ref_group:
             resolved_references[ref] = ref.resolve(
-                store=store, cache=cache, on_missing=on_missing
+                store, cache=cache, on_missing=on_missing
             )
 
     return resolved_references
@@ -390,7 +404,7 @@ def find_and_get_references(arg: Any) -> Tuple[OutputReference, ...]:
 
 def find_and_resolve_references(
     arg: Any,
-    store: Optional[jobflow.JobStore] = None,
+    store: jobflow.JobStore,
     cache: Optional[Dict[str, Any]] = None,
     on_missing: OnMissing = OnMissing.ERROR,
 ) -> Any:
@@ -425,7 +439,7 @@ def find_and_resolve_references(
 
     if isinstance(arg, OutputReference):
         # if the argument is a reference then stop there
-        return arg.resolve(store=store, cache=cache, on_missing=on_missing)
+        return arg.resolve(store, cache=cache, on_missing=on_missing)
 
     elif isinstance(arg, (float, int, str, bool)):
         # argument is a primitive, we won't find a reference here
@@ -445,10 +459,7 @@ def find_and_resolve_references(
         OutputReference.from_dict(get(encoded_arg, list(loc))) for loc in locations
     ]
     resolved_references = resolve_references(
-        references,
-        store=store,
-        cache=cache,
-        on_missing=on_missing,
+        references, store, cache=cache, on_missing=on_missing
     )
 
     # replace the references in the arg dict

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -172,6 +172,7 @@ def test_replace_response(memory_jobstore):
     assert response.replace.jobs[-1].uuid == test_job.uuid
     assert response.replace.jobs[-1].metadata == metadata
     assert response.replace.jobs[-1].output_schema == "123"
+    assert response.replace.output is not None
 
     # replace with flow with multi outputs
     test_job = Job(replace_flow_multioutput, metadata=metadata, output_schema="123")
@@ -181,6 +182,7 @@ def test_replace_response(memory_jobstore):
     assert response.replace.jobs[-1].uuid == test_job.uuid
     assert response.replace.jobs[-1].metadata == metadata
     assert response.replace.jobs[-1].output_schema == "123"
+    assert response.replace.output is not None
 
     # replace with list of flow
     test_job = Job(replace_list_flow, metadata=metadata, output_schema="123")

--- a/tests/core/test_maker.py
+++ b/tests/core/test_maker.py
@@ -13,6 +13,30 @@ def test_bad_subclass():
     with pytest.raises(NotImplementedError):
         BadMaker().make()
 
+    @dataclass
+    class BadMaker(Maker):
+
+        a = 1
+
+    with pytest.raises(NotImplementedError):
+        BadMaker().name()
+
+
+def test_required_arguments_works():
+    from dataclasses import dataclass
+
+    @dataclass
+    class MyMaker:
+
+        a: int
+        name = "123"
+
+    m = MyMaker(1)
+    assert m.a == 1
+
+    with pytest.raises(TypeError):
+        MyMaker()
+
 
 def test_job_maker():
     from dataclasses import dataclass

--- a/tests/core/test_reference.py
+++ b/tests/core/test_reference.py
@@ -185,19 +185,15 @@ def test_resolve(memory_jobstore):
     ref = OutputReference("123")
 
     # fail if cache or store not provided
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         ref.resolve()
 
-    # resolve using cache
-    cache = {"123": "xyz"}
-    assert ref.resolve(cache=cache) == "xyz"
-
     # test on missing
-    assert ref.resolve(cache={}, on_missing=OnMissing.NONE) is None
-    assert ref.resolve(cache={}, on_missing=OnMissing.PASS) == ref
+    assert ref.resolve(memory_jobstore, on_missing=OnMissing.NONE) is None
+    assert ref.resolve(memory_jobstore, on_missing=OnMissing.PASS) == ref
 
     with pytest.raises(ValueError):
-        ref.resolve(cache={}, on_missing=OnMissing.ERROR)
+        ref.resolve(memory_jobstore, on_missing=OnMissing.ERROR)
 
     # resolve using store
     memory_jobstore.update({"uuid": "123", "index": 1, "output": 101})
@@ -206,54 +202,51 @@ def test_resolve(memory_jobstore):
     # resolve using store and empty cache
     cache = {}
     assert ref.resolve(store=memory_jobstore, cache=cache) == 101
-    assert cache["123"] == 101
+    assert cache["123"][1] == 101
 
     # check cache supersedes store
-    cache = {"123": "xyz"}
+    cache = {"123": {1: "xyz"}}
     assert ref.resolve(store=memory_jobstore, cache=cache) == "xyz"
-    assert cache["123"] == "xyz"
+    assert cache["123"][1] == "xyz"
 
     # test indexing
     ref = OutputReference("123", (("i", "a"), ("i", 1)))
-    cache = {"123": {"a": [5, 6, 7]}}
-    assert ref.resolve(cache=cache) == 6
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": {"a": [5, 6, 7]}})
+    assert ref.resolve(memory_jobstore) == 6
 
     # test attribute access
     ref = OutputReference("123", (("a", "__module__"),))
-    cache = {"123": OutputReference}
-    assert ref.resolve(cache=cache) == "jobflow.core.reference"
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": OutputReference})
+    assert ref.resolve(memory_jobstore) == "jobflow.core.reference"
 
     # test missing attribute throws error
     ref = OutputReference("123", (("a", "b"),))
-
-    cache = {"123": [1234]}
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": [1234]})
     with pytest.raises(AttributeError):
-        ref.resolve(cache=cache)
+        ref.resolve(memory_jobstore)
 
     # test missing index throws error
     ref = OutputReference("123", (("i", "b"),))
-
-    cache = {"123": [1234]}
     with pytest.raises(TypeError):
-        ref.resolve(cache=cache)
+        ref.resolve(memory_jobstore)
 
 
 def test_resolve_references(memory_jobstore):
     from jobflow import OnMissing, OutputReference
     from jobflow.core.reference import resolve_references
 
-    # resolve single using cache
+    # resolve single using store
     ref = OutputReference("123")
-    cache = {"123": "xyz"}
-    output = resolve_references([ref], cache=cache)
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": "xyz"})
+    output = resolve_references([ref], memory_jobstore)
     assert len(output) == 1
     assert output[ref] == "xyz"
 
     # resolve multiple using cache
     ref1 = OutputReference("123")
     ref2 = OutputReference("1234")
-    cache = {"123": "xyz", "1234": 101}
-    output = resolve_references([ref1, ref2], cache=cache)
+    memory_jobstore.update({"uuid": "1234", "index": 1, "output": 101})
+    output = resolve_references([ref1, ref2], memory_jobstore)
     assert len(output) == 2
     assert output[ref1] == "xyz"
     assert output[ref2] == 101
@@ -262,8 +255,10 @@ def test_resolve_references(memory_jobstore):
     ref1 = OutputReference("123", (("i", "a"),))
     ref2 = OutputReference("123", (("i", "b"),))
     ref3 = OutputReference("1234")
-    cache = {"123": {"a": "xyz", "b": "abc"}, "1234": 101}
-    output = resolve_references([ref1, ref2, ref3], cache=cache)
+    memory_jobstore.update(
+        {"uuid": "123", "index": 1, "output": {"a": "xyz", "b": "abc"}}
+    )
+    output = resolve_references([ref1, ref2, ref3], memory_jobstore)
     assert len(output) == 3
     assert output[ref1] == "xyz"
     assert output[ref2] == "abc"
@@ -271,49 +266,40 @@ def test_resolve_references(memory_jobstore):
 
     # test on missing
     ref1 = OutputReference("123")
-    ref2 = OutputReference("1234")
-    cache = {"123": "xyz"}
-    output = resolve_references([ref1, ref2], cache=cache, on_missing=OnMissing.NONE)
-    assert len(output) == 2
-    assert output[ref1] == "xyz"
-    assert output[ref2] is None
-
-    cache = {"123": "xyz"}
-    output = resolve_references([ref1, ref2], cache=cache, on_missing=OnMissing.PASS)
+    ref2 = OutputReference("12345")
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": "xyz"})
+    output = resolve_references(
+        [ref1, ref2], memory_jobstore, on_missing=OnMissing.PASS
+    )
     assert len(output) == 2
     assert output[ref1] == "xyz"
     assert output[ref2] == ref2
 
+    ref2 = OutputReference("12345")
     with pytest.raises(ValueError):
-        resolve_references([ref1, ref2], cache={}, on_missing=OnMissing.ERROR)
-
-    # resolve using store
-    memory_jobstore.update({"uuid": "123", "index": 1, "output": "xyz"})
-    output = resolve_references([ref], store=memory_jobstore)
-    assert len(output) == 1
-    assert output[ref] == "xyz"
+        resolve_references([ref1, ref2], memory_jobstore, on_missing=OnMissing.ERROR)
 
     # resolve using store and empty cache
     cache = {}
-    output = resolve_references([ref], store=memory_jobstore, cache=cache)
+    output = resolve_references([ref], memory_jobstore, cache=cache)
     assert len(output) == 1
     assert output[ref] == "xyz"
 
     # check cache supersedes store
-    cache = {"123": 101}
-    output = resolve_references([ref], store=memory_jobstore, cache=cache)
+    cache = {"123": {1: 101}}
+    output = resolve_references([ref], memory_jobstore, cache=cache)
     assert len(output) == 1
     assert output[ref] == 101
 
     # test attributes
     ref = OutputReference("123", (("i", "a"), ("i", 1)))
-    cache = {"123": {"a": [5, 6, 7]}}
-    output = resolve_references([ref], cache=cache)
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": {"a": [5, 6, 7]}})
+    output = resolve_references([ref], memory_jobstore)
     assert output[ref] == 6
 
     ref = OutputReference("123", (("a", "__module__"),))
-    cache = {"123": OutputReference}
-    output = resolve_references([ref], cache=cache)
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": OutputReference})
+    output = resolve_references([ref], memory_jobstore)
     assert output[ref] == "jobflow.core.reference"
 
 
@@ -349,47 +335,38 @@ def test_find_and_resolve_references(memory_jobstore):
 
     ref1 = OutputReference("123")
     ref2 = OutputReference("1234", (("i", "a"),))
-    cache = {"123": 101, "1234": {"a": "xyz", "b": 5}}
+    memory_jobstore.update({"uuid": "123", "index": 1, "output": 101})
+    memory_jobstore.update({"uuid": "1234", "index": 1, "output": {"a": "xyz", "b": 5}})
 
     # test no reference
-    assert find_and_resolve_references(True, cache=cache) == True
-    assert find_and_resolve_references("xyz", cache=cache) == "xyz"
-    assert find_and_resolve_references([101], cache=cache) == [101]
+    assert find_and_resolve_references(True, memory_jobstore) is True
+    assert find_and_resolve_references("xyz", memory_jobstore) == "xyz"
+    assert find_and_resolve_references([101], memory_jobstore) == [101]
 
     # test single reference
-    assert find_and_resolve_references(ref1, cache=cache) == 101
+    assert find_and_resolve_references(ref1, memory_jobstore) == 101
 
     # test list and tuple of references
-    assert find_and_resolve_references([ref1], cache=cache) == [101]
-    assert find_and_resolve_references([ref1, ref2], cache=cache) == [101, "xyz"]
+    assert find_and_resolve_references([ref1], memory_jobstore) == [101]
+    assert find_and_resolve_references([ref1, ref2], memory_jobstore) == [101, "xyz"]
 
     # test dictionary dictionary values
-    output = find_and_resolve_references({"a": ref1}, cache=cache)
+    output = find_and_resolve_references({"a": ref1}, memory_jobstore)
     assert output == {"a": 101}
-    output = find_and_resolve_references({"a": ref1, "b": ref2}, cache=cache)
+    output = find_and_resolve_references({"a": ref1, "b": ref2}, memory_jobstore)
     assert output == {
         "a": 101,
         "b": "xyz",
     }
 
     # test nested
-    output = find_and_resolve_references({"a": [ref1, ref2]}, cache=cache)
+    output = find_and_resolve_references({"a": [ref1, ref2]}, memory_jobstore)
     assert output == {"a": [101, "xyz"]}
-    output = find_and_resolve_references([{"a": ref1}, {"b": ref2}], cache=cache)
+    output = find_and_resolve_references([{"a": ref1}, {"b": ref2}], memory_jobstore)
     assert output == [
         {"a": 101},
         {"b": "xyz"},
     ]
-
-    # test store, no cache
-    memory_jobstore.update(
-        [
-            {"uuid": "123", "index": 1, "output": 101},
-            {"uuid": "1234", "index": 1, "output": {"a": "xyz", "b": 5}},
-        ]
-    )
-    output = find_and_resolve_references({"a": [ref1, ref2]}, store=memory_jobstore)
-    assert output == {"a": [101, "xyz"]}
 
     # test store, blank cache
     cache = {}
@@ -397,26 +374,26 @@ def test_find_and_resolve_references(memory_jobstore):
         {"a": [ref1, ref2]}, store=memory_jobstore, cache=cache
     )
     assert output == {"a": [101, "xyz"]}
-    assert cache["123"] == 101
+    assert cache["123"][1] == 101
 
     # test cache overrides store
     output = find_and_resolve_references(
-        {"a": [ref1, ref2]}, store=memory_jobstore, cache={"123": 1}
+        {"a": [ref1, ref2]}, store=memory_jobstore, cache={"123": {1: 1}}
     )
     assert output == {"a": [1, "xyz"]}
 
     # test on missing
-    cache = {"123": 101}
+    ref3 = OutputReference("12345", (("i", "a"),))
     output = find_and_resolve_references(
-        [ref1, ref2], cache=cache, on_missing=OnMissing.PASS
+        [ref1, ref3], memory_jobstore, on_missing=OnMissing.PASS
     )
-    assert output == [101, ref2]
+    assert output == [101, ref3]
     output = find_and_resolve_references(
-        [ref1, ref2], cache=cache, on_missing=OnMissing.NONE
+        [ref1, ref3], memory_jobstore, on_missing=OnMissing.NONE
     )
     assert output == [101, None]
 
     with pytest.raises(ValueError):
         find_and_resolve_references(
-            [ref1, ref2], cache=cache, on_missing=OnMissing.ERROR
+            [ref1, ref3], memory_jobstore, on_missing=OnMissing.ERROR
         )

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -343,9 +343,10 @@ def test_get_output(memory_jobstore):
         memory_jobstore.get_output("5")
 
     r1 = {"@module": "jobflow.core.reference", "@class": "OutputReference", "uuid": "5"}
-    memory_jobstore.update({"uuid": "5", "index": 1, "output": [r1, 123]})
+    memory_jobstore.update({"uuid": "5", "index": 1, "output": r1})
+    memory_jobstore.update({"uuid": "5", "index": 2, "output": r1})
     with pytest.raises(RuntimeError):
-        memory_jobstore.get_output("5")
+        memory_jobstore.get_output("5", which="all")
 
 
 def test_from_db_file(test_data):

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -280,6 +280,8 @@ def test_remove_docs(memory_jobstore, memory_data_jobstore):
 
 
 def test_get_output(memory_jobstore):
+    from jobflow import OnMissing
+
     docs = [
         {"uuid": "1", "index": 1, "output": "xyz"},
         {"uuid": "1", "index": 2, "output": "abc"},
@@ -302,11 +304,43 @@ def test_get_output(memory_jobstore):
     output = memory_jobstore.get_output("1", which="all")
     assert output == ["xyz", "abc", 123, "a"]
 
+    output = memory_jobstore.get_output("1", which=1)
+    assert output == "xyz"
+
+    output = memory_jobstore.get_output("1", which=3)
+    assert output == 123
+
     with pytest.raises(ValueError):
         memory_jobstore.get_output(1, which="first")
 
     with pytest.raises(ValueError):
         memory_jobstore.get_output(1, which="all")
+
+    # test catching circular reference
+    r = {"@module": "jobflow.core.reference", "@class": "OutputReference", "uuid": "5"}
+    memory_jobstore.update({"uuid": "5", "index": 1, "output": r})
+    with pytest.raises(RuntimeError):
+        memory_jobstore.get_output("5")
+
+    # test resolving reference in output of job
+    r = {"@module": "jobflow.core.reference", "@class": "OutputReference", "uuid": "10"}
+    docs = [
+        {"uuid": "5", "index": 1, "output": r},
+        {"uuid": "6", "index": 1, "output": {"a": r, "b": 5}},
+        {"uuid": "10", "index": 1, "output": "xyz"},
+    ]
+    memory_jobstore.update(docs)
+    assert memory_jobstore.get_output("5") == "xyz"
+    assert memory_jobstore.get_output("6") == {"a": "xyz", "b": 5}
+
+    # test missing reference in output of job
+    r = {"@module": "jobflow.core.reference", "@class": "OutputReference", "uuid": "a"}
+    memory_jobstore.update({"uuid": "8", "index": 1, "output": r})
+    with pytest.raises(ValueError):
+        memory_jobstore.get_output("8", on_missing=OnMissing.ERROR)
+
+    assert memory_jobstore.get_output("8", on_missing=OnMissing.NONE) is None
+    assert memory_jobstore.get_output("8", on_missing=OnMissing.PASS).uuid == r["uuid"]
 
 
 def test_from_db_file(test_data):

--- a/tests/managers/conftest.py
+++ b/tests/managers/conftest.py
@@ -123,14 +123,14 @@ def replace_job_with_flow(simple_job):
     @job
     def replace_func_flow(a, b):
         first_job = simple_job(str(a + b))
-        second_job = simple_job(str(a + b) + first_job.output)
+        second_job = simple_job(first_job.output)
         flow = Flow(
             [first_job, second_job],
             {"first": first_job.output, "second": second_job.output},
         )
         return Response(output=a + b, replace=flow)
 
-    return replace_func
+    return replace_func_flow
 
 
 @pytest.fixture(scope="session")
@@ -139,6 +139,18 @@ def replace_flow(replace_job, simple_job):
 
     def _gen():
         replace = replace_job(5, 6)
+        simple = simple_job("12345")
+        return Flow([replace, simple], simple.output, order=JobOrder.LINEAR)
+
+    return _gen
+
+
+@pytest.fixture(scope="session")
+def replace_flow_nested(replace_job_with_flow, simple_job):
+    from jobflow import Flow, JobOrder
+
+    def _gen():
+        replace = replace_job_with_flow(5, 6)
         simple = simple_job("12345")
         return Flow([replace, simple], simple.output, order=JobOrder.LINEAR)
 

--- a/tests/managers/conftest.py
+++ b/tests/managers/conftest.py
@@ -115,6 +115,25 @@ def replace_job(simple_job):
 
 
 @pytest.fixture(scope="session")
+def replace_job_with_flow(simple_job):
+    from jobflow import Flow, Response, job
+
+    global replace_func_flow
+
+    @job
+    def replace_func_flow(a, b):
+        first_job = simple_job(str(a + b))
+        second_job = simple_job(str(a + b) + first_job.output)
+        flow = Flow(
+            [first_job, second_job],
+            {"first": first_job.output, "second": second_job.output},
+        )
+        return Response(output=a + b, replace=flow)
+
+    return replace_func
+
+
+@pytest.fixture(scope="session")
 def replace_flow(replace_job, simple_job):
     from jobflow import Flow, JobOrder
 

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -184,7 +184,7 @@ def test_replace_flow(memory_jobstore, clean_dir, replace_flow, capsys):
     assert len(responses[uuid1]) == 2
     assert responses[uuid1][1].output == 11
     assert responses[uuid1][1].replace is not None
-    assert responses[uuid1][2].output == "11_end"
+    assert responses[uuid1][2].output == {"a": "11_end"}
     assert responses[uuid2][1].output == "12345_end"
 
     # check store has the activity output
@@ -193,7 +193,7 @@ def test_replace_flow(memory_jobstore, clean_dir, replace_flow, capsys):
     result3 = memory_jobstore.query_one({"uuid": uuid2, "index": 1})
 
     assert result1["output"] == 11
-    assert result2["output"] == "11_end"
+    assert result2["output"] == {"a": "11_end"}
     assert result3["output"] == "12345_end"
 
     # assert job2 (replaced job) ran before job3

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -1,4 +1,4 @@
-def test_simple_job(memory_jobstore, clean_dir, simple_job, capsys):
+def test_simple_job(memory_jobstore, clean_dir, simple_job):
     from jobflow import run_locally
 
     # run with log
@@ -60,7 +60,7 @@ def test_simple_flow(memory_jobstore, clean_dir, simple_flow, capsys):
     assert len(folders) == 1
 
 
-def test_connected_flow(memory_jobstore, clean_dir, connected_flow, capsys):
+def test_connected_flow(memory_jobstore, clean_dir, connected_flow):
     from jobflow import run_locally
 
     flow = connected_flow()
@@ -83,7 +83,7 @@ def test_connected_flow(memory_jobstore, clean_dir, connected_flow, capsys):
     assert result2["output"] == "12345_end_end"
 
 
-def test_nested_flow(memory_jobstore, clean_dir, nested_flow, capsys):
+def test_nested_flow(memory_jobstore, clean_dir, nested_flow):
     from jobflow import run_locally
 
     flow = nested_flow()
@@ -114,7 +114,7 @@ def test_nested_flow(memory_jobstore, clean_dir, nested_flow, capsys):
     assert result4["output"] == "12345_end_end_end_end"
 
 
-def test_addition_flow(memory_jobstore, clean_dir, addition_flow, capsys):
+def test_addition_flow(memory_jobstore, clean_dir, addition_flow):
     from jobflow import run_locally
 
     flow = addition_flow()
@@ -138,7 +138,7 @@ def test_addition_flow(memory_jobstore, clean_dir, addition_flow, capsys):
     assert result2["output"] == "11_end"
 
 
-def test_detour_flow(memory_jobstore, clean_dir, detour_flow, capsys):
+def test_detour_flow(memory_jobstore, clean_dir, detour_flow):
     from jobflow import run_locally
 
     flow = detour_flow()
@@ -169,7 +169,7 @@ def test_detour_flow(memory_jobstore, clean_dir, detour_flow, capsys):
     assert result2["completed_at"] < result3["completed_at"]
 
 
-def test_replace_flow(memory_jobstore, clean_dir, replace_flow, capsys):
+def test_replace_flow(memory_jobstore, clean_dir, replace_flow):
     from jobflow import run_locally
 
     flow = replace_flow()
@@ -184,7 +184,7 @@ def test_replace_flow(memory_jobstore, clean_dir, replace_flow, capsys):
     assert len(responses[uuid1]) == 2
     assert responses[uuid1][1].output == 11
     assert responses[uuid1][1].replace is not None
-    assert responses[uuid1][2].output == {"a": "11_end"}
+    assert responses[uuid1][2].output == "11_end"
     assert responses[uuid2][1].output == "12345_end"
 
     # check store has the activity output
@@ -193,14 +193,45 @@ def test_replace_flow(memory_jobstore, clean_dir, replace_flow, capsys):
     result3 = memory_jobstore.query_one({"uuid": uuid2, "index": 1})
 
     assert result1["output"] == 11
-    assert result2["output"] == {"a": "11_end"}
+    assert result2["output"] == "11_end"
     assert result3["output"] == "12345_end"
 
     # assert job2 (replaced job) ran before job3
     assert result2["completed_at"] < result3["completed_at"]
 
 
-def test_stop_jobflow_flow(memory_jobstore, clean_dir, stop_jobflow_flow, capsys):
+def test_replace_flow_nested(memory_jobstore, clean_dir, replace_flow_nested):
+    from jobflow import run_locally
+
+    flow = replace_flow_nested()
+    uuid1 = flow.jobs[0].uuid
+    uuid2 = flow.jobs[1].uuid
+
+    # run with log
+    responses = run_locally(flow, store=memory_jobstore)
+
+    # check responses has been filled
+    assert len(responses) == 4
+    assert len(responses[uuid1]) == 2
+    assert responses[uuid1][1].output == 11
+    assert responses[uuid1][1].replace is not None
+    assert responses[uuid1][2].output["first"].__class__.__name__ == "OutputReference"
+    assert responses[uuid2][1].output == "12345_end"
+
+    # check store has the activity output
+    result1 = memory_jobstore.query_one({"uuid": uuid1, "index": 1})
+    result2 = memory_jobstore.query_one({"uuid": uuid1, "index": 2})
+    result3 = memory_jobstore.query_one({"uuid": uuid2, "index": 1})
+
+    assert result1["output"] == 11
+    assert result2["output"]["first"]["@class"] == "OutputReference"
+    assert result3["output"] == "12345_end"
+
+    # assert job2 (replaced job) ran before job3
+    assert result2["completed_at"] < result3["completed_at"]
+
+
+def test_stop_jobflow_flow(memory_jobstore, clean_dir, stop_jobflow_flow):
     from jobflow import run_locally
 
     flow = stop_jobflow_flow()
@@ -221,7 +252,7 @@ def test_stop_jobflow_flow(memory_jobstore, clean_dir, stop_jobflow_flow, capsys
     assert result1["output"] == "1234"
 
 
-def test_stop_jobflow_job(memory_jobstore, clean_dir, stop_jobflow_job, capsys):
+def test_stop_jobflow_job(memory_jobstore, clean_dir, stop_jobflow_job):
     from jobflow import run_locally
 
     job = stop_jobflow_job()
@@ -242,7 +273,7 @@ def test_stop_jobflow_job(memory_jobstore, clean_dir, stop_jobflow_job, capsys):
     assert result1["output"] == "1234"
 
 
-def test_stop_children_flow(memory_jobstore, clean_dir, stop_children_flow, capsys):
+def test_stop_children_flow(memory_jobstore, clean_dir, stop_children_flow):
     from jobflow import run_locally
 
     flow = stop_children_flow()
@@ -299,7 +330,7 @@ def test_stored_data_flow(memory_jobstore, clean_dir, stored_data_flow, capsys):
     assert "Response.stored_data is not supported" in captured.out
 
 
-def test_detour_stop_flow(memory_jobstore, clean_dir, detour_stop_flow, capsys):
+def test_detour_stop_flow(memory_jobstore, clean_dir, detour_stop_flow):
     from jobflow import run_locally
 
     flow = detour_stop_flow()


### PR DESCRIPTION
## Summary

Updates for version 0.1.

Enhancements:

- ``JobStore.get_output`` now resolves references in the output of other jobs.
- ``JobStore.get_output``: ``which`` now supports specifying a specific job index.
- Better support for circular and missing references in ``JobStore.get_output`` and
  ``OutputReference.resolve``.
- Update dependencies to use latest jsanitize features.

Bug fixes:
- Makes now allows non-default parameters (fixes: #13).
- Fix reference cache with multiple indexes.