### PR TITLE
Clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Some of its features include:
 Workflows in jobflows are made up of two main components:
 
 - A `Job` is an atomic computing job. Essentially any python function can be `Job`,
-  provided its return values can be serialized to json. Anything returned by the job is
+  provided its input and return values can be serialized to json. Anything returned by the job is
   considered an "output" and is stored in the jobflow database.
 - A `Flow` is a collection of `Job` objects or other `Flow` objects. The connectivity
   between jobs is determined automatically from the job inputs. The execution order

--- a/tutorials/1-quickstart.ipynb
+++ b/tutorials/1-quickstart.ipynb
@@ -307,7 +307,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "Now that you’ve successfully run your first Flow, we encourage you to learn about all the different options jobflow provides for designing and running workflows. A good next step is the [Introductory tutorial](https://hackingmaterials.lbl.gov/jobflow/tutorials/2-introduction.html), which covers things more slowly than this quickstart."
+    "Now that you’ve successfully run your first Flow, we encourage you to learn about all the different options jobflow provides for designing and running workflows. A good next step is the [Introductory tutorial](https://materialsproject.github.io/jobflow/tutorials/2-introduction.html), which covers things more slowly than this quickstart."
    ]
   }
  ],


### PR DESCRIPTION
Two changes to the docs:
1. The docs say that a `Job` requires the returns to be serializable to JSON. It's also true that the inputs must be serializable, which I think is important to note. It wasn't intuitive to me at least.
2. I fixed a broken URL.

```python
~\Anaconda3\envs\cms2\lib\site-packages\jobflow\core\job.py in get_job(*args, **kwargs)
    200                         args = args[1:]
    201
--> 202             return Job(
    203                 function=f,
    204                 function_args=args,

~\Anaconda3\envs\cms2\lib\site-packages\jobflow\core\job.py in __init__(self, function, function_args, function_kwargs, output_schema, uuid, index, name, metadata, config, host, **kwargs)
    353         # this is a possible situation but likely a mistake
    354         all_args = tuple(self.function_args) + tuple(self.function_kwargs.values())
--> 355         if contains_flow_or_job(all_args):
    356             warnings.warn(
    357                 f"Job '{self.name}' contains an Flow or Job as an input. "

~\Anaconda3\envs\cms2\lib\site-packages\jobflow\utils\find.py in contains_flow_or_job(obj)
    214         return False
    215
--> 216     obj = jsanitize(obj, strict=True)
    217
    218     # recursively find any reference classes

~\Anaconda3\envs\cms2\lib\site-packages\monty\json.py in jsanitize(obj, strict, allow_bson, enum_values)
    478         return obj
    479     if isinstance(obj, (list, tuple)):
--> 480         return [jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values) for i in obj]
    481     if np is not None and isinstance(obj, np.ndarray):
    482         return [jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values) for i in obj.tolist()]

~\Anaconda3\envs\cms2\lib\site-packages\monty\json.py in <listcomp>(.0)
    478         return obj
    479     if isinstance(obj, (list, tuple)):
--> 480         return [jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values) for i in obj]
    481     if np is not None and isinstance(obj, np.ndarray):
    482         return [jsanitize(i, strict=strict, allow_bson=allow_bson, enum_values=enum_values) for i in obj.tolist()]

~\Anaconda3\envs\cms2\lib\site-packages\monty\json.py in jsanitize(obj, strict, allow_bson, enum_values)
    508         return jsanitize(MontyEncoder().default(obj), strict=strict, allow_bson=allow_bson, enum_values=enum_values)
    509
--> 510     return jsanitize(obj.as_dict(), strict=strict, allow_bson=allow_bson, enum_values=enum_values)
    511
    512

AttributeError: 'Atoms' object has no attribute 'as_dict'
```