### PR TITLE
[WIP] Allow for multiple filters in update_kwargs and update_maker_kwargs

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -332,7 +332,7 @@ class Flow(MSONable):
         self,
         update: Dict[str, Any],
         name_filter: Optional[str | List[str]] = None,
-        class_filter: Optional[Type[jobflow.Maker] | List[jobflow.Maker]] = None,
+        class_filter: Optional[Type[jobflow.Maker] | List[Type[jobflow.Maker]]] = None,
         nested: bool = True,
         dict_mod: bool = False,
     ):

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -277,8 +277,8 @@ class Flow(MSONable):
     def update_kwargs(
         self,
         update: Dict[str, Any],
-        name_filter: Optional[str] = None,
-        function_filter: Optional[Callable] = None,
+        name_filter: Optional[str | List[str]] = None,
+        function_filter: Optional[Callable | List[Callable]] = None,
         dict_mod: bool = False,
     ):
         """
@@ -291,9 +291,9 @@ class Flow(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the job name.
+            A filter (or list of filters) for the job name.
         function_filter
-            Only filter matching functions.
+            A filter (or list of filters) matching the function.
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
@@ -331,8 +331,8 @@ class Flow(MSONable):
     def update_maker_kwargs(
         self,
         update: Dict[str, Any],
-        name_filter: Optional[str] = None,
-        class_filter: Optional[Type[jobflow.Maker]] = None,
+        name_filter: Optional[str | List[str]] = None,
+        class_filter: Optional[Type[jobflow.Maker] | List[jobflow.Maker]] = None,
         nested: bool = True,
         dict_mod: bool = False,
     ):
@@ -346,10 +346,10 @@ class Flow(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the Maker name.
+            A filter (or list of filters) for the Maker name.
         class_filter
-            A filter for the maker class. Note the class filter will match any
-            subclasses.
+            A filter (or list of filters) for the maker class. Note the class filter
+            will match any subclasses.
         nested
             Whether to apply the updates to Maker objects that are themselves kwargs
             of Maker, job, or flow objects. See examples for more details.

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -648,9 +648,9 @@ class Job(MSONable):
         """
         from jobflow.utils.dict_mods import apply_mod
 
-        if not type(name_filter, list):
+        if not isinstance(name_filter, list):
             name_filter = [name_filter]
-        if not type(function_filter, list):
+        if not isinstance(function_filter, list):
             function_filter = [function_filter]
 
         if function_filter is not None and self.function not in function_filter:

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -613,8 +613,8 @@ class Job(MSONable):
     def update_kwargs(
         self,
         update: Dict[str, Any],
-        name_filter: Optional[str] = None,
-        function_filter: Optional[Callable] = None,
+        name_filter: Optional[str | List[str]] = None,
+        function_filter: Optional[Callable | List[callable]] = None,
         dict_mod: bool = False,
     ):
         """
@@ -625,9 +625,9 @@ class Job(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the job name.
+            A filter (or list of filters) for the job name.
         function_filter
-            Only filter matching functions.
+            A filter (or list of filters) matching the function.
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
@@ -648,13 +648,18 @@ class Job(MSONable):
         """
         from jobflow.utils.dict_mods import apply_mod
 
-        if function_filter is not None and function_filter != self.function:
+        if not type(name_filter, list):
+            name_filter = [name_filter]
+        if not type(function_filter, list):
+            function_filter = [function_filter]
+
+        if function_filter is not None and self.function not in function_filter:
             return
 
         if (
             name_filter is not None
             and self.name is not None
-            and name_filter not in self.name
+            and self.name not in name_filter
         ):
             return
 
@@ -667,8 +672,8 @@ class Job(MSONable):
     def update_maker_kwargs(
         self,
         update: Dict[str, Any],
-        name_filter: Optional[str] = None,
-        class_filter: Optional[Type[jobflow.Maker]] = None,
+        name_filter: Optional[str | List[str]] = None,
+        class_filter: Optional[Type[jobflow.Maker] | List[Type[jobflow.Maker]]] = None,
         nested: bool = True,
         dict_mod: bool = False,
     ):
@@ -680,10 +685,10 @@ class Job(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the Maker name.
+            A filter (or list of filters) for the Maker name.
         class_filter
-            A filter for the maker class. Note the class filter will match any
-            subclasses.
+            A filter (or list of filters) for the maker class. Note the class filter
+            will match any subclasses.
         nested
             Whether to apply the updates to Maker objects that are themselves kwargs
             of Maker, job, or flow objects. See examples for more details.

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -614,7 +614,7 @@ class Job(MSONable):
         self,
         update: Dict[str, Any],
         name_filter: Optional[str | List[str]] = None,
-        function_filter: Optional[Callable | List[callable]] = None,
+        function_filter: Optional[Callable | List[Callable]] = None,
         dict_mod: bool = False,
     ):
         """
@@ -648,9 +648,9 @@ class Job(MSONable):
         """
         from jobflow.utils.dict_mods import apply_mod
 
-        if not isinstance(name_filter, list):
+        if name_filter and not isinstance(name_filter, list):
             name_filter = [name_filter]
-        if not isinstance(function_filter, list):
+        if function_filter and not isinstance(function_filter, list):
             function_filter = [function_filter]
 
         if function_filter is not None and self.function not in function_filter:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -515,13 +515,13 @@ def test_update_kwargs():
     flow.update_kwargs({"b": 5}, function_filter=div)
     assert "b" not in flow.jobs[0].function_kwargs
     assert flow.jobs[1].function_kwargs["b"] == 5
-    assert flow.jobs[1].function_kwargs["b"] == 4
+    assert flow.jobs[2].function_kwargs["b"] == 4
 
     flow = get_test_flow()
     flow.update_kwargs({"b": 5}, function_filter=[div])
     assert "b" not in flow.jobs[0].function_kwargs
     assert flow.jobs[1].function_kwargs["b"] == 5
-    assert flow.jobs[1].function_kwargs["b"] == 4
+    assert flow.jobs[2].function_kwargs["b"] == 4
 
     flow = get_test_flow()
     flow.update_kwargs({"b": 10}, name_filter=[div, mult])

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -524,7 +524,7 @@ def test_update_kwargs():
     assert flow.jobs[2].function_kwargs["b"] == 4
 
     flow = get_test_flow()
-    flow.update_kwargs({"b": 10}, name_filter=[div, mult])
+    flow.update_kwargs({"b": 10}, function_filter=[div, mult])
     assert "b" not in flow.jobs[0].function_kwargs
     assert flow.jobs[1].function_kwargs["b"] == 10
     assert flow.jobs[2].function_kwargs["b"] == 10

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -686,6 +686,10 @@ def test_update_kwargs():
     test_job.update_kwargs({"b": 5}, name_filter="div")
     assert test_job.function_kwargs["b"] == 2
 
+    test_job = Job(add, function_args=(1,), function_kwargs={"b": 2})
+    test_job.update_kwargs({"b": 5}, name_filter=["div", "test"])
+    assert test_job.function_kwargs["b"] == 2
+
     # test function filter
     test_job = Job(add, function_args=(1,), function_kwargs={"b": 2})
     test_job.update_kwargs({"b": 5}, function_filter=add)
@@ -693,6 +697,10 @@ def test_update_kwargs():
 
     test_job = Job(add, function_args=(1,), function_kwargs={"b": 2})
     test_job.update_kwargs({"b": 5}, function_filter=list)
+    assert test_job.function_kwargs["b"] == 2
+
+    test_job = Job(add, function_args=(1,), function_kwargs={"b": 2})
+    test_job.update_kwargs({"b": 5}, function_filter=[list])
     assert test_job.function_kwargs["b"] == 2
 
     # test dict mod


### PR DESCRIPTION
## Summary
Currently, the `name_filter`, `function_filter`, and `class_filter` kwargs in the `update_kwargs` and `update_maker_kwargs` functions of jobs and flows only allow for a single filter. For complex flows in particular, this can become quite cumbersome if you want to update the kwargs of several underlying jobs or makers (but not all of them).

This PR makes it possible to pass a list of filters (in addition to just a single filter) so that the user doesn't have to call `update_kwargs` or `update_maker_kwargs` several times in succession. 