### PR TITLE
Update divmaker test

### DIFF
--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -44,7 +44,7 @@ def get_maker_flow(return_makers=False):
 
         @job
         def make(self, a):
-            return a + self.b
+            return a / self.b
 
     add_maker = AddMaker(b=3)
     div_maker = DivMaker(b=4)


### PR DESCRIPTION
It bothered me that the `DivMaker` in the unit test was an addition operator instead of a division operator. Now updated. Functionally, this does absolutely nothing to the existing unit tests, but... *shrugs*