### PR TITLE
[WIP]Add list of hosts to Job document

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -140,7 +140,7 @@ def job(method: Optional[Callable] = None, **job_kwargs):
         doesn't exist, this error will only be raised when the Job is executed.
 
     Jobs can return :obj:`.Response` objects that control the flow execution flow.
-    For example, to replace the current jub with another job, ``replace`` can be used.
+    For example, to replace the current job with another job, ``replace`` can be used.
 
     >>> from jobflow import Response
     >>> @job

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -9,9 +9,10 @@ from monty.json import MontyDecoder, MontyEncoder, MSONable, jsanitize
 
 from jobflow.utils.enum import ValueEnum
 
-if typing.TYPE_CHECKING:
+from pydantic import BaseModel
+from pydantic.utils import lenient_issubclass
 
-    from pydantic import BaseModel
+if typing.TYPE_CHECKING:
 
     import jobflow
 
@@ -221,10 +222,11 @@ class OutputReference(MSONable):
 
     def __getitem__(self, item) -> OutputReference:
         """Index the reference."""
+        subschema = None
         if self.output_schema is not None:
-            validate_schema_access(self.output_schema, item)
+            _, subschema = validate_schema_access(self.output_schema, item)
 
-        return OutputReference(self.uuid, self.attributes + (("i", item),))
+        return OutputReference(self.uuid, self.attributes + (("i", item),), output_schema=subschema)
 
     def __getattr__(self, item) -> OutputReference:
         """Attribute access of the reference."""
@@ -234,10 +236,11 @@ class OutputReference(MSONable):
             # This is necessary to trick monty/pydantic.
             raise AttributeError
 
+        subschema = None
         if self.output_schema is not None:
-            validate_schema_access(self.output_schema, item)
+            _, subschema = validate_schema_access(self.output_schema, item)
 
-        return OutputReference(self.uuid, self.attributes + (("a", item),))
+        return OutputReference(self.uuid, self.attributes + (("a", item),), output_schema=subschema)
 
     def __setattr__(self, attr, val):
         """Set attribute."""
@@ -472,9 +475,12 @@ def find_and_resolve_references(
     return MontyDecoder().process_decoded(encoded_arg)
 
 
-def validate_schema_access(schema: Type[BaseModel], item: str):
+def validate_schema_access(
+    schema: Type[BaseModel], item: str
+) -> Tuple[bool, Optional[BaseModel]]:
     """
     Validate that an attribute or index access is supported by a model.
+    If the item is associated to a nested model the class is returned.
 
     Parameters
     ----------
@@ -490,10 +496,17 @@ def validate_schema_access(schema: Type[BaseModel], item: str):
 
     Returns
     -------
-    bool
-        Returns ``True`` if the schema access was valid.
+    tuple[bool, BaseModel]
+        the bool is ``True`` if the schema access was valid.
+        The BaseModel class associted with the item, if any.
     """
     schema_dict = schema.schema()
     if item not in schema_dict["properties"]:
         raise AttributeError(f"{schema.__name__} does not have attribute '{item}'.")
-    return True
+
+    subschema = None
+    item_type = schema.__fields__[item].type_
+    if lenient_issubclass(item_type, BaseModel):
+        subschema = item_type
+
+    return True, subschema

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,5 +1,6 @@
 """Settings for jobflow."""
 
+import os
 from pathlib import Path
 
 from maggma.stores import MemoryStore
@@ -7,7 +8,7 @@ from pydantic import BaseSettings, Field, root_validator
 
 from jobflow import JobStore
 
-DEFAULT_CONFIG_FILE_PATH = "~/.jobflow.yaml"
+DEFAULT_CONFIG_FILE_PATH = os.path.expanduser("~/.jobflow.yaml")
 
 __all__ = ["JobflowSettings"]
 

--- a/tutorials/1-quickstart.ipynb
+++ b/tutorials/1-quickstart.ipynb
@@ -234,7 +234,7 @@
    "id": "productive-belarus",
    "metadata": {},
    "source": [
-    "The `run_locally` function returns the output of all jobs. The the format of the output is:\n",
+    "The `run_locally` function returns the output of all jobs. The format of the output is:\n",
     "\n",
     "```python\n",
     "{\n",


### PR DESCRIPTION
## Summary

Following previous discussion, here is a draft for the storage of the list of uuids of the Flows containing a job. The idea is to be able to group jobs belonging to the same Flow when querying the Job store. 

The list of hosts is supposed to be ordered in such a way that the first element is the first Flow containing the Job/Flow, with subsequent elements identifying the increasing containers.

The list is stored in the `hosts` attribute. In principle this could entirely replace the `host`, since this should always be the first element of the `hosts`. I can change that as well, if there are no other specific usage of `host`.
I will implement the tests if the current model of handling `hosts` is approved.

A few other additional changes:
* fix the path to the default config file
* validate nested schemas in pydantic models.
* fix few typos

## TODO (if any)

* tests
