### PR TITLE
List of hosts in Jobs and Flows

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -60,11 +60,9 @@ class Flow(MSONable):
         the order automatically based on the connections between jobs.
     uuid
         The identifier of the flow. This is genenrated automatically.
-    host
-        The identifier of the host flow. This is set automatically when an flow
-        is included in the jobs array of another flow.
     hosts
-        The list of UUIDs of the hosts containing the job.
+        The list of UUIDs of the hosts containing the job. This is updated
+        automatically when a flow is included in the jobs array of another flow.
 
     Raises
     ------
@@ -125,7 +123,6 @@ class Flow(MSONable):
         name: str = "Flow",
         order: JobOrder = JobOrder.AUTO,
         uuid: str = None,
-        host: str = None,
         hosts: Optional[List[str]] = None,
     ):
         from jobflow.core.job import Job
@@ -142,7 +139,6 @@ class Flow(MSONable):
         self.name = name
         self.order = order
         self.uuid = uuid
-        self.host = host
         self.hosts = hosts or []
 
         job_ids = set()
@@ -157,7 +153,6 @@ class Flow(MSONable):
                     "jobs array contains multiple jobs/flows with the same uuid "
                     f"({job.uuid})"
                 )
-            job.host = self.uuid
             job_ids.add(job.uuid)
 
         if self.output is not None:
@@ -178,7 +173,7 @@ class Flow(MSONable):
                     "jobs array does not contain all jobs needed for flow output"
                 )
 
-        self.add_hosts_uuids(self.uuid)
+        self.add_hosts_uuids()
 
     @property
     def job_uuids(self) -> Tuple[str, ...]:
@@ -232,6 +227,18 @@ class Flow(MSONable):
                     edges.append((leaf, root, {"properties": ""}))
             graph.add_edges_from(edges)
         return graph
+
+    @property
+    def host(self):
+        """
+        UUID of the first Flow that contains this Flow.
+
+        Returns
+        -------
+        str
+            the UUID of the host.
+        """
+        return self.hosts[0] if self.hosts else None
 
     def draw_graph(self, **kwargs):
         """
@@ -451,10 +458,15 @@ class Flow(MSONable):
         for job in self.jobs:
             job.append_name(append_str, prepend=prepend)
 
-    def add_hosts_uuids(self, hosts_uuids: Union[str, List[str]], prepend: bool = False):
+    def add_hosts_uuids(
+        self, hosts_uuids: Optional[Union[str, List[str]]] = None, prepend: bool = False
+    ):
         """
-        Add a list of UUIDs to the internal list of hosts. The same action is
-        applied to the contained Flows ond Jobs.
+        Add a list of UUIDs to the internal list of hosts.
+
+        If hosts_uuids is None the uuid of this Flow will be added to the inner jobs and
+        flow. Otherwise, the passed value will be set both in the list of hosts
+        of the current flow and of the inner jobs and flows.
         The elements of the list are supposed to be ordered in such a way that
         the object identified by one UUID of the list is contained in objects
         identified by its subsequent elements.
@@ -462,16 +474,20 @@ class Flow(MSONable):
         Parameters
         ----------
         hosts_uuids
-            A list of UUIDs to add.
+            A list of UUIDs to add. If None the current uuid of the flow will be
+            added to the inner Flows and Jobs.
         prepend
             Insert the UUIDs at the beginning of the list rather than extending it.
         """
-        if not isinstance(hosts_uuids, (list, tuple)):
-            hosts_uuids = [hosts_uuids]
-        if prepend:
-            self.hosts[0:0] = hosts_uuids
+        if hosts_uuids is not None:
+            if not isinstance(hosts_uuids, (list, tuple)):
+                hosts_uuids = [hosts_uuids]
+            if prepend:
+                self.hosts[0:0] = hosts_uuids
+            else:
+                self.hosts.extend(hosts_uuids)
         else:
-            self.hosts.extend(hosts_uuids)
+            hosts_uuids = [self.uuid]
         for j in self.jobs:
             j.add_hosts_uuids(hosts_uuids, prepend=prepend)
 

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -140,7 +140,7 @@ def job(method: Optional[Callable] = None, **job_kwargs):
         doesn't exist, this error will only be raised when the Job is executed.
 
     Jobs can return :obj:`.Response` objects that control the flow execution flow.
-    For example, to replace the current jub with another job, ``replace`` can be used.
+    For example, to replace the current job with another job, ``replace`` can be used.
 
     >>> from jobflow import Response
     >>> @job

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -591,3 +591,20 @@ def test_get_flow():
     job1 = Job(add, function_args=(1, 2))
     job2 = Job(add, function_args=(job1.output.value, 2))
     get_flow([job1, job2])
+
+
+def test_hosts():
+    from jobflow.core.flow import Flow
+
+    # test single job
+    add_job1 = get_test_job()
+    add_job2 = get_test_job()
+    flow1 = Flow(add_job1)
+    flow2 = Flow([flow1, add_job2])
+    flow3 = Flow(flow2)
+
+    assert add_job1.hosts == [flow1.uuid, flow2.uuid, flow3.uuid]
+    assert add_job2.hosts == [flow2.uuid, flow3.uuid]
+    assert flow1.hosts == [flow2.uuid, flow3.uuid]
+    assert flow2.hosts == [flow3.uuid]
+    assert flow3.hosts == []

--- a/tutorials/1-quickstart.ipynb
+++ b/tutorials/1-quickstart.ipynb
@@ -234,7 +234,7 @@
    "id": "productive-belarus",
    "metadata": {},
    "source": [
-    "The `run_locally` function returns the output of all jobs. The the format of the output is:\n",
+    "The `run_locally` function returns the output of all jobs. The format of the output is:\n",
     "\n",
     "```python\n",
     "{\n",


### PR DESCRIPTION
## Summary

Allowing the storage of the list of uuids of the Flows containing a job. The idea is to be able to group jobs belonging to the same Flow when querying the Job store.

The list of hosts is supposed to be ordered in such a way that the first element is the first Flow containing the Job/Flow, with subsequent elements identifying the increasing containers.

The list is stored in the `hosts` attribute. `host` is removed and replaced by a property giving the first element of `hosts`, if present. 

An additional issue that emerged was that, when using Fireworks as a manager, for restart, detours and additions the new Jobs are always wrapped inside a Flow, leading to clashes with the list of `hosts`. The easiest way that I have found to fix this was to always wrap restart/detour/addition Jobs into a Flow during the `Job.run()`. Is this acceptable?

An additional open point is the fact that the list of jobs inside `Flow` is accessible by the client code without any restriction. This makes impossible to guarantee that the jobs in that list has the correct list of hosts properly set.  This seems also a general issue, since all the checks on the Jobs performed in `__init__` are skipped if someone tampers with the jobs list directly.  
I propose to make the list of `jobs` in Flow not directly accessible and provide an API to modify it through a method of `Flow`, that will also take charge of performing all the required actions to properly add a new job to the list. `jobs` could be either a tuple, or could be stored internally as a list under `_jobs` and the `job` property returns a copy of the list, so that it cannot be directly modified.  
Would you agree to switch to this approach?