### PR TITLE
Validate subschema

### DIFF
--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -9,9 +9,10 @@ from monty.json import MontyDecoder, MontyEncoder, MSONable, jsanitize
 
 from jobflow.utils.enum import ValueEnum
 
-if typing.TYPE_CHECKING:
+from pydantic import BaseModel
+from pydantic.utils import lenient_issubclass
 
-    from pydantic import BaseModel
+if typing.TYPE_CHECKING:
 
     import jobflow
 
@@ -221,10 +222,11 @@ class OutputReference(MSONable):
 
     def __getitem__(self, item) -> OutputReference:
         """Index the reference."""
+        subschema = None
         if self.output_schema is not None:
-            validate_schema_access(self.output_schema, item)
+            _, subschema = validate_schema_access(self.output_schema, item)
 
-        return OutputReference(self.uuid, self.attributes + (("i", item),))
+        return OutputReference(self.uuid, self.attributes + (("i", item),), output_schema=subschema)
 
     def __getattr__(self, item) -> OutputReference:
         """Attribute access of the reference."""
@@ -234,10 +236,11 @@ class OutputReference(MSONable):
             # This is necessary to trick monty/pydantic.
             raise AttributeError
 
+        subschema = None
         if self.output_schema is not None:
-            validate_schema_access(self.output_schema, item)
+            _, subschema = validate_schema_access(self.output_schema, item)
 
-        return OutputReference(self.uuid, self.attributes + (("a", item),))
+        return OutputReference(self.uuid, self.attributes + (("a", item),), output_schema=subschema)
 
     def __setattr__(self, attr, val):
         """Set attribute."""
@@ -472,9 +475,12 @@ def find_and_resolve_references(
     return MontyDecoder().process_decoded(encoded_arg)
 
 
-def validate_schema_access(schema: Type[BaseModel], item: str):
+def validate_schema_access(
+    schema: Type[BaseModel], item: str
+) -> Tuple[bool, Optional[BaseModel]]:
     """
     Validate that an attribute or index access is supported by a model.
+    If the item is associated to a nested model the class is returned.
 
     Parameters
     ----------
@@ -490,10 +496,17 @@ def validate_schema_access(schema: Type[BaseModel], item: str):
 
     Returns
     -------
-    bool
-        Returns ``True`` if the schema access was valid.
+    tuple[bool, BaseModel]
+        the bool is ``True`` if the schema access was valid.
+        The BaseModel class associted with the item, if any.
     """
     schema_dict = schema.schema()
     if item not in schema_dict["properties"]:
         raise AttributeError(f"{schema.__name__} does not have attribute '{item}'.")
-    return True
+
+    subschema = None
+    item_type = schema.__fields__[item].type_
+    if lenient_issubclass(item_type, BaseModel):
+        subschema = item_type
+
+    return True, subschema

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -6,11 +6,10 @@ import typing
 from typing import Any, Dict, Optional, Sequence, Tuple, Type
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable, jsanitize
-
-from jobflow.utils.enum import ValueEnum
-
 from pydantic import BaseModel
 from pydantic.utils import lenient_issubclass
+
+from jobflow.utils.enum import ValueEnum
 
 if typing.TYPE_CHECKING:
 
@@ -226,7 +225,9 @@ class OutputReference(MSONable):
         if self.output_schema is not None:
             _, subschema = validate_schema_access(self.output_schema, item)
 
-        return OutputReference(self.uuid, self.attributes + (("i", item),), output_schema=subschema)
+        return OutputReference(
+            self.uuid, self.attributes + (("i", item),), output_schema=subschema
+        )
 
     def __getattr__(self, item) -> OutputReference:
         """Attribute access of the reference."""
@@ -240,7 +241,9 @@ class OutputReference(MSONable):
         if self.output_schema is not None:
             _, subschema = validate_schema_access(self.output_schema, item)
 
-        return OutputReference(self.uuid, self.attributes + (("a", item),), output_schema=subschema)
+        return OutputReference(
+            self.uuid, self.attributes + (("a", item),), output_schema=subschema
+        )
 
     def __setattr__(self, attr, val):
         """Set attribute."""
@@ -480,6 +483,7 @@ def validate_schema_access(
 ) -> Tuple[bool, Optional[BaseModel]]:
     """
     Validate that an attribute or index access is supported by a model.
+
     If the item is associated to a nested model the class is returned.
 
     Parameters
@@ -505,8 +509,9 @@ def validate_schema_access(
         raise AttributeError(f"{schema.__name__} does not have attribute '{item}'.")
 
     subschema = None
-    item_type = schema.__fields__[item].type_
+    item_type = schema.__fields__[item].outer_type_
     if lenient_issubclass(item_type, BaseModel):
         subschema = item_type
 
+    print(item, item_type, subschema)
     return True, subschema


### PR DESCRIPTION
## Summary

Implement a first level of validation of outputs with nested Schemas.

The current implementation ignores the checks if nested schemas are inside `Union`, `List`, `Dict`, while it correctly validates if inside `Optional`. 

As previously discussed (#116), implementing the checks for `Union` will probably be challenging and it will not be supported for the time being. Should we do the same for `List` and `Dict`?