### PR TITLE
fix home path

### DIFF
--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,5 +1,6 @@
 """Settings for jobflow."""
 
+import os
 from pathlib import Path
 
 from maggma.stores import MemoryStore
@@ -7,7 +8,7 @@ from pydantic import BaseSettings, Field, root_validator
 
 from jobflow import JobStore
 
-DEFAULT_CONFIG_FILE_PATH = "~/.jobflow.yaml"
+DEFAULT_CONFIG_FILE_PATH = os.path.expanduser("~/.jobflow.yaml")
 
 __all__ = ["JobflowSettings"]
 


### PR DESCRIPTION
## Summary

Explicitly replace the `~` for the `DEFAULT_CONFIG_FILE_PATH`.

I actually have to amend what I said yesterday(#116): it seems that I still have the same issue. In particular, looking at the code, it seems that the `DEFAULT_CONFIG_FILE_PATH` is used here:

https://github.com/materialsproject/jobflow/blob/fbd5868394c6f4f6b4f2e0ccf4b7ff7d21fe7258/src/jobflow/settings.py#L92

and it does not look like the expanduser gets applied to this anywhere before being accessed. Am I missing something?