### PR TITLE
Pass an alternate manager_config to child jobs made via a detour, addition, or replacement

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -57,6 +57,10 @@ class JobConfig(MSONable):
     pass_manager_config
         Whether to pass the manager configuration on to detour, addition, and
         replacement jobs.
+    downstream_manager_config
+        The manager configuration to pass on a detour, addition, or replacement job if
+        different than the default manager_config. Using this kwarg will automatically
+        override the behavior of ``pass_manager_config``.
 
     Returns
     -------
@@ -69,6 +73,7 @@ class JobConfig(MSONable):
     manager_config: dict = field(default_factory=dict)
     expose_store: bool = False
     pass_manager_config: bool = True
+    downstream_manager_config: dict = None
 
 
 def job(method: Optional[Callable] = None, **job_kwargs):
@@ -527,15 +532,20 @@ class Job(MSONable):
         if response.replace is not None:
             response.replace = prepare_replace(response.replace, self)
 
-        if self.config.pass_manager_config:
+        if self.config.pass_manager_config or self.config.downstream_manager_config:
+            if self.config.downstream_manager_config:
+                passed_config = self.config.downstream_manager_config
+            else:
+                passed_config = self.config.manager_config
+
             if response.addition is not None:
-                pass_manager_config(response.addition, self.config.manager_config)
+                pass_manager_config(response.addition, passed_config)
 
             if response.detour is not None:
-                pass_manager_config(response.detour, self.config.manager_config)
+                pass_manager_config(response.detour, passed_config)
 
             if response.replace is not None:
-                pass_manager_config(response.replace, self.config.manager_config)
+                pass_manager_config(response.replace, passed_config)
 
         try:
             output = jsanitize(response.output, strict=True, enum_values=True)

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -58,7 +58,7 @@ class JobConfig(MSONable):
         Whether to pass the manager configuration on to detour, addition, and
         replacement jobs.
     response_manager_config
-        The custom configuration to pass on a detour, addition, or replacement job.
+        The custom configuration to pass to a detour, addition, or replacement job.
         Using this kwarg will automatically take precedence over the behavior of ``pass_manager_config``
         such that a different configuration than ``manger_config`` can be passed to downstream
         jobs.
@@ -74,7 +74,7 @@ class JobConfig(MSONable):
     manager_config: dict = field(default_factory=dict)
     expose_store: bool = False
     pass_manager_config: bool = True
-    response_manager_config: dict = None
+    response_manager_config: dict = field(default_factory=dict)
 
 
 def job(method: Optional[Callable] = None, **job_kwargs):

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -57,10 +57,10 @@ class JobConfig(MSONable):
     pass_manager_config
         Whether to pass the manager configuration on to detour, addition, and
         replacement jobs.
-    downstream_manager_config
+    response_manager_config
         The manager configuration to pass on a detour, addition, or replacement job if
         different than the default manager_config. Using this kwarg will automatically
-        override the behavior of ``pass_manager_config``.
+        take precedence over the behavior of ``pass_manager_config``.
 
     Returns
     -------
@@ -73,7 +73,7 @@ class JobConfig(MSONable):
     manager_config: dict = field(default_factory=dict)
     expose_store: bool = False
     pass_manager_config: bool = True
-    downstream_manager_config: dict = None
+    response_manager_config: dict = None
 
 
 def job(method: Optional[Callable] = None, **job_kwargs):
@@ -532,8 +532,8 @@ class Job(MSONable):
         if response.replace is not None:
             response.replace = prepare_replace(response.replace, self)
 
-        if self.config.downstream_manager_config:
-            passed_config = self.config.downstream_manager_config
+        if self.config.response_manager_config:
+            passed_config = self.config.response_manager_config
         elif self.config.pass_manager_config:
             passed_config = self.config.manager_config
         else:

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -532,11 +532,14 @@ class Job(MSONable):
         if response.replace is not None:
             response.replace = prepare_replace(response.replace, self)
 
-        if self.config.pass_manager_config or self.config.downstream_manager_config:
-            if self.config.downstream_manager_config:
-                passed_config = self.config.downstream_manager_config
-            else:
-                passed_config = self.config.manager_config
+        if self.config.downstream_manager_config:
+            passed_config = self.config.downstream_manager_config
+        elif self.config.pass_manager_config:
+            passed_config = self.config.manager_config
+        else:
+            passed_config = None
+
+        if passed_config:
 
             if response.addition is not None:
                 pass_manager_config(response.addition, passed_config)

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -58,9 +58,10 @@ class JobConfig(MSONable):
         Whether to pass the manager configuration on to detour, addition, and
         replacement jobs.
     response_manager_config
-        The manager configuration to pass on a detour, addition, or replacement job if
-        different than the default manager_config. Using this kwarg will automatically
-        take precedence over the behavior of ``pass_manager_config``.
+        The custom configuration to pass on a detour, addition, or replacement job.
+        Using this kwarg will automatically take precedence over the behavior of ``pass_manager_config``
+        such that a different configuration than ``manger_config`` can be passed to downstream
+        jobs.
 
     Returns
     -------

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -285,8 +285,12 @@ def test_job_config(memory_jobstore):
         return Response(detour=job)
 
     manager_config = {"abc": 1}
+    manager_config2 = {"abc": 2}
     pass_config = JobConfig(manager_config=manager_config, pass_manager_config=True)
     nopass_config = JobConfig(manager_config=manager_config, pass_manager_config=False)
+    downstream_config = JobConfig(
+        manager_config=manager_config, downstream_manager_config=manager_config2
+    )
 
     # test replace
     test_job = Job(replace_job, config=nopass_config)
@@ -296,6 +300,10 @@ def test_job_config(memory_jobstore):
     test_job = Job(replace_job, config=pass_config)
     response = test_job.run(memory_jobstore)
     assert response.replace.config.manager_config == manager_config
+
+    test_job = Job(replace_job, config=downstream_config)
+    response = test_job.run(memory_jobstore)
+    assert response.replace.config.manager_config == manager_config2
 
     # test replace list of jobs
     test_job = Job(replace_list_job, config=nopass_config)
@@ -308,6 +316,11 @@ def test_job_config(memory_jobstore):
     for j in response.replace.jobs:
         assert j.config.manager_config == manager_config
 
+    test_job = Job(replace_list_job, config=downstream_config)
+    response = test_job.run(memory_jobstore)
+    for j in response.replace.jobs:
+        assert j.config.manager_config == manager_config2
+
     # test replace with flow
     test_job = Job(replace_flow, config=nopass_config)
     response = test_job.run(memory_jobstore)
@@ -319,6 +332,11 @@ def test_job_config(memory_jobstore):
     for j in response.replace.jobs:
         assert j.config.manager_config == manager_config
 
+    test_job = Job(replace_flow, config=downstream_config)
+    response = test_job.run(memory_jobstore)
+    for j in response.replace.jobs:
+        assert j.config.manager_config == manager_config2
+
     # test addition
     test_job = Job(addition_job, config=nopass_config)
     response = test_job.run(memory_jobstore)
@@ -328,6 +346,10 @@ def test_job_config(memory_jobstore):
     response = test_job.run(memory_jobstore)
     assert response.addition.config.manager_config == manager_config
 
+    test_job = Job(addition_job, config=downstream_config)
+    response = test_job.run(memory_jobstore)
+    assert response.addition.config.manager_config == manager_config2
+
     # test detour
     test_job = Job(detour_job, config=nopass_config)
     response = test_job.run(memory_jobstore)
@@ -336,6 +358,10 @@ def test_job_config(memory_jobstore):
     test_job = Job(detour_job, config=pass_config)
     response = test_job.run(memory_jobstore)
     assert response.detour.config.manager_config == manager_config
+
+    test_job = Job(detour_job, config=downstream_config)
+    response = test_job.run(memory_jobstore)
+    assert response.detour.config.manager_config == manager_config2
 
 
 def test_job_input_references():

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -288,8 +288,8 @@ def test_job_config(memory_jobstore):
     manager_config2 = {"abc": 2}
     pass_config = JobConfig(manager_config=manager_config, pass_manager_config=True)
     nopass_config = JobConfig(manager_config=manager_config, pass_manager_config=False)
-    downstream_config = JobConfig(
-        manager_config=manager_config, downstream_manager_config=manager_config2
+    response_config = JobConfig(
+        manager_config=manager_config, response_manager_config=manager_config2
     )
 
     # test replace
@@ -301,7 +301,7 @@ def test_job_config(memory_jobstore):
     response = test_job.run(memory_jobstore)
     assert response.replace.config.manager_config == manager_config
 
-    test_job = Job(replace_job, config=downstream_config)
+    test_job = Job(replace_job, config=response_config)
     response = test_job.run(memory_jobstore)
     assert response.replace.config.manager_config == manager_config2
 
@@ -316,7 +316,7 @@ def test_job_config(memory_jobstore):
     for j in response.replace.jobs:
         assert j.config.manager_config == manager_config
 
-    test_job = Job(replace_list_job, config=downstream_config)
+    test_job = Job(replace_list_job, config=response_config)
     response = test_job.run(memory_jobstore)
     for j in response.replace.jobs:
         assert j.config.manager_config == manager_config2
@@ -332,7 +332,7 @@ def test_job_config(memory_jobstore):
     for j in response.replace.jobs:
         assert j.config.manager_config == manager_config
 
-    test_job = Job(replace_flow, config=downstream_config)
+    test_job = Job(replace_flow, config=response_config)
     response = test_job.run(memory_jobstore)
     for j in response.replace.jobs:
         assert j.config.manager_config == manager_config2
@@ -346,7 +346,7 @@ def test_job_config(memory_jobstore):
     response = test_job.run(memory_jobstore)
     assert response.addition.config.manager_config == manager_config
 
-    test_job = Job(addition_job, config=downstream_config)
+    test_job = Job(addition_job, config=response_config)
     response = test_job.run(memory_jobstore)
     assert response.addition.config.manager_config == manager_config2
 
@@ -359,7 +359,7 @@ def test_job_config(memory_jobstore):
     response = test_job.run(memory_jobstore)
     assert response.detour.config.manager_config == manager_config
 
-    test_job = Job(detour_job, config=downstream_config)
+    test_job = Job(detour_job, config=response_config)
     response = test_job.run(memory_jobstore)
     assert response.detour.config.manager_config == manager_config2
 


### PR DESCRIPTION
Addresses #120. 

Currently, it is not possible to modify the `manager_config` of any jobs produced from a detour, addition, or replacement. The only option is the default (`pass_manager_config=True`), which passes the parent job's config to the child or `pass_manager_config=False` which passes a clean slate. Ideally, there should be a way for the user to pass a dictionary that won't be used in the parent job but will be used for any downstream jobs.

That is what this PR does. It adds a new kwarg `response_manager_config` to `JobConfig` for precisely this purpose.

Example:
```python
job.config.response_manager_config["_fworker"] = "my_response_fworker"
```