### PR TITLE
add s3store yaml parsing

### DIFF
--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -661,13 +661,14 @@ class JobStore(Store):
 
 
 def _construct_store(spec_dict, valid_stores):
-    """Parse the dict containing {"type": <StoreType>} recursively"""
+    """Parse the dict containing {"type": <StoreType>} recursively."""
     print(spec_dict)
     store_type = spec_dict.pop("type")
-    for k,v in spec_dict.items():
+    for k, v in spec_dict.items():
         if isinstance(v, dict) and "type" in v:
             spec_dict[k] = _construct_store(v, valid_stores)
     return valid_stores[store_type](**spec_dict)
+
 
 def _prepare_load(
     load: load_type,

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -64,7 +64,7 @@ class JobStore(Store):
         # enforce uuid key
         self.docs_store.key = "uuid"
         for additional_store in self.additional_stores.values():
-            additional_store.key = "blob_id"
+            additional_store.key = "blob_uuid"
 
         if save is None or save is False:
             save = {}

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -651,17 +651,23 @@ class JobStore(Store):
         all_stores = {s.__name__: s for s in all_subclasses(maggma.stores.Store)}
 
         docs_store_info = spec["docs_store"]
-        docs_store_type = docs_store_info.pop("type")
-        docs_store = all_stores[docs_store_type](**docs_store_info)
+        docs_store = _construct_store(docs_store_info, all_stores)
 
         additional_stores = {}
         if "additional_stores" in spec:
             for store_name, info in spec["additional_stores"].items():
-                store_type = info.pop("type")
-                additional_stores[store_name] = all_stores[store_type](**info)
-
+                additional_stores[store_name] = _construct_store(info, all_stores)
         return cls(docs_store, additional_stores, **kwargs)
 
+
+def _construct_store(spec_dict, valid_stores):
+    """Parse the dict containing {"type": <StoreType>} recursively"""
+    print(spec_dict)
+    store_type = spec_dict.pop("type")
+    for k,v in spec_dict.items():
+        if isinstance(v, dict) and "type" in v:
+            spec_dict[k] = _construct_store(v, valid_stores)
+    return valid_stores[store_type](**spec_dict)
 
 def _prepare_load(
     load: load_type,

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -58,7 +58,7 @@ class JobflowSettings(BaseSettings):
             host: localhost
             port: 27017
 
-    S3Store example:
+    S3Store example (Note: the ``key`` field must be set to ``blob_uuid``):
 
     .. code-block:: yaml
 
@@ -72,12 +72,14 @@ class JobflowSettings(BaseSettings):
           data:
             type: S3Store
             bucket: output_blobs
+            key: blob_uuid
             index:
               type: MongoStore
               database: jobflow_unittest
               collection_name: output_blobs_index
               host: localhost
               port: 27017
+              key: blob_uuid
 
 
     Lastly, the store can be specified as a file name that points to a file containing

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -38,7 +38,9 @@ class JobflowSettings(BaseSettings):
     docs_store and additional stores are specified by the ``type`` key which must match
     a Maggma ``Store`` subclass, and the remaining keys are passed to the store
     constructor. For example, the following file would  create a :obj:`JobStore` with a
-    ``MongoStore`` for docs and a ``GridFSStore`` as an additional store for data.
+    ``MongoStore`` for docs and a ``GridFSStore`` or ``S3Store`` as an additional store for data.
+
+    GridFSStore example:
 
     .. code-block:: yaml
 
@@ -55,6 +57,28 @@ class JobflowSettings(BaseSettings):
             collection_name: outputs_blobs
             host: localhost
             port: 27017
+
+    S3Store example:
+
+    .. code-block:: yaml
+
+        docs_store:
+          type: MongoStore
+          database: jobflow_unittest
+          collection_name: outputs
+          host: localhost
+          port: 27017
+        additional_stores:
+          data:
+            type: S3Store
+            bucket: output_blobs
+            index:
+              type: MongoStore
+              database: jobflow_unittest
+              collection_name: output_blobs_index
+              host: localhost
+              port: 27017
+
 
     Lastly, the store can be specified as a file name that points to a file containing
     the credentials in any format supported by :obj:`.JobStore.from_file`.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,6 @@
+from random import setstate
+
+
 def test_settings_init():
     from maggma.stores import MemoryStore
 
@@ -41,6 +44,22 @@ def test_settings_object(clean_dir, test_data):
         }
     }
 
+    s3_store_spec = {
+        "docs_store": {
+            "type": "MemoryStore",
+            "collection_name": "docs_store_123",
+        },
+        "additional_stores": {
+            "data": {
+                "type": "S3Store",
+                "bucket": "bucket_123",
+                "index": {
+                    "type": "MemoryStore",
+                }
+            }
+        },
+    }
+
     # set the path to lood settings from
     os.environ["JOBFLOW_CONFIG_FILE"] = str(Path.cwd() / "config.yaml")
 
@@ -53,6 +72,10 @@ def test_settings_object(clean_dir, test_data):
     dumpfn({"JOB_STORE": dict_spec}, "config.yaml")
     settings = JobflowSettings()
     assert settings.JOB_STORE.docs_store.collection_name == "outputs_567"
+
+    dumpfn({"JOB_STORE": s3_store_spec}, "config.yaml")
+    settings = JobflowSettings()
+    assert settings.JOB_STORE.additional_stores["data"].bucket == "bucket_0"
 
     # assert loading from db file works.
     dumpfn({"JOB_STORE": str(test_data / "db.yaml")}, "config.yaml")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -72,7 +72,7 @@ def test_settings_object(clean_dir, test_data):
 
     dumpfn({"JOB_STORE": s3_store_spec}, "config.yaml")
     settings = JobflowSettings()
-    assert settings.JOB_STORE.additional_stores["data"].bucket == "bucket_0"
+    assert settings.JOB_STORE.additional_stores["data"].bucket == "bucket_123"
 
     # assert loading from db file works.
     dumpfn({"JOB_STORE": str(test_data / "db.yaml")}, "config.yaml")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,3 @@
-from random import setstate
-
-
 def test_settings_init():
     from maggma.stores import MemoryStore
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -52,7 +52,7 @@ def test_settings_object(clean_dir, test_data):
                 "bucket": "bucket_123",
                 "index": {
                     "type": "MemoryStore",
-                }
+                },
             }
         },
     }


### PR DESCRIPTION
## Fixed parsing of nested stores (Ex. S3Store)
Now checks the `dict_spec` for the word "type" and recursively calls the constructor.