### PR TITLE
Typo fixes

### DIFF
--- a/examples/restarts.py
+++ b/examples/restarts.py
@@ -35,7 +35,7 @@ def start_timing_jobs(websites: List[str]):
         jobs.append(time_job)
 
     output = [j.output for j in jobs]
-    return Response(restart=Flow(jobs, output))
+    return Response(replace=Flow(jobs, output))
 
 
 @job
@@ -44,7 +44,7 @@ def sum_times(times: List[float]):
 
 
 # create a flow that will:
-# 1. load a list of websites from a file.
+# 1. load a list of websites from a file
 # 2. generate one new job for each website to time the website loading
 # 3. sum all the times together
 read_websites_job = read_websites()

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -233,12 +233,15 @@ class Flow(MSONable):
 
         Requires matplotlib to be installed.
 
+        Parameters
+        ----------
+        kwargs
+            keyword arguments that are passed to :obj:`jobflow.utils.graph.draw_graph`.
+
         Returns
         -------
         pyplot
             The matplotlib pyplot state object.
-        kwargs
-            keyword arguments that are passed to :obj:`jobflow.utils.graph.draw_graph`.
         """
         from jobflow.utils.graph import draw_graph
 

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -59,9 +59,9 @@ class JobConfig(MSONable):
         replacement jobs.
     response_manager_config
         The custom configuration to pass to a detour, addition, or replacement job.
-        Using this kwarg will automatically take precedence over the behavior of ``pass_manager_config``
-        such that a different configuration than ``manger_config`` can be passed to downstream
-        jobs.
+        Using this kwarg will automatically take precedence over the behavior of
+        ``pass_manager_config`` such that a different configuration than ``manger_config``
+        can be passed to downstream jobs.
 
     Returns
     -------

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -61,7 +61,7 @@ class OutputReference(MSONable):
     ----------
     uuid
         The job uuid to which the output belongs.
-    attributes :
+    attributes
         A tuple of attributes or indexes that have been performed on the
         output. Attributes are specified by a tuple of ``("a", attr)``, whereas
         indexes are specified as a tuple of ``("i", index)``.

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -61,7 +61,7 @@ class OutputReference(MSONable):
     ----------
     uuid
         The job uuid to which the output belongs.
-    attributes
+    attributes :
         A tuple of attributes or indexes that have been performed on the
         output. Attributes are specified by a tuple of ``("a", attr)``, whereas
         indexes are specified as a tuple of ``("i", index)``.

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -54,7 +54,6 @@ class JobStore(Store):
         save: save_type = None,
         load: load_type = False,
     ):
-        """ """
         self.docs_store = docs_store
         if additional_stores is None:
             self.additional_stores = {}
@@ -189,7 +188,7 @@ class JobStore(Store):
                 # 1. Find the locations of all blob identifiers.
                 # 2. Filter the locations based on the load criteria.
                 # 3. Resolve all data blobs using the data store.
-                # 4. Insert the data blobs into the document
+                # 4. Insert the data blobs into the document.
                 locations = find_key(doc, "blob_uuid")
                 all_blobs = [get(doc, list(loc)) for loc in locations]
                 grouped_blobs = _filter_blobs(all_blobs, locations, load_keys)
@@ -600,7 +599,7 @@ class JobStore(Store):
 
         .. note::
             This function is different to ``JobStore.from_dict`` which is used to load
-            the monty serialised representation of the claas.
+            the monty serialised representation of the class.
 
         The dictionary should contain the keys "docs_store", "additional_stores" and
         any other keyword arguments supported by the :obj:`JobStore` constructor. The

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -34,7 +34,7 @@ def run_locally(
     store
         A job store. If a job store is not specified then
         :obj:`JobflowSettings.JOB_STORE` will be used. By default this is a maggma
-        ``MemoryStore`` but can customised by setting the jobflow configuration file.
+        ``MemoryStore`` but can be customised by setting the jobflow configuration file.
     create_folders
         Whether to run each job in a new folder.
     ensure_success

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,6 +1,5 @@
 """Settings for jobflow."""
 
-import os
 from pathlib import Path
 
 from maggma.stores import MemoryStore
@@ -8,7 +7,7 @@ from pydantic import BaseSettings, Field, root_validator
 
 from jobflow import JobStore
 
-DEFAULT_CONFIG_FILE_PATH = os.path.expanduser("~/.jobflow.yaml")
+DEFAULT_CONFIG_FILE_PATH = Path("~/.jobflow.yaml").expanduser().as_posix()
 
 __all__ = ["JobflowSettings"]
 
@@ -39,7 +38,8 @@ class JobflowSettings(BaseSettings):
     docs_store and additional stores are specified by the ``type`` key which must match
     a Maggma ``Store`` subclass, and the remaining keys are passed to the store
     constructor. For example, the following file would  create a :obj:`JobStore` with a
-    ``MongoStore`` for docs and a ``GridFSStore`` or ``S3Store`` as an additional store for data.
+    ``MongoStore`` for docs and a ``GridFSStore`` or ``S3Store`` as an additional store
+    for data.
 
     GridFSStore example:
 


### PR DESCRIPTION
## Summary

* Fix `restart.py` example, restart->replace
* A few typo fixes
