### PR TITLE
Control changes to job list in Flow

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -261,7 +261,8 @@ class Job(MSONable):
     config
         The config setting for the job.
     hosts
-        The list of UUIDs of the hosts containing the job.
+        The list of UUIDs of the hosts containing the job. The object identified by one
+        UUID of the list should be contained in objects identified by its subsequent elements.
     **kwargs
         Additional keyword arguments that can be used to specify which outputs to save
         in additional stores. The argument name gives the additional store name and the
@@ -1052,8 +1053,7 @@ def prepare_replace(
         store_output_job.index = current_job.index + 1
         store_output_job.metadata = current_job.metadata
         store_output_job.output_schema = current_job.output_schema
-        store_output_job.add_hosts_uuids(replace.uuid)
-        replace.jobs.append(store_output_job)
+        replace.add_jobs(store_output_job)
 
     elif isinstance(replace, Job):
         # replace is a single Job

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,11 @@
 def test_settings_init():
+    import os
+
     from maggma.stores import MemoryStore
+
+    # set the config file to a not existing path so that it does not
+    # pick the local configuration
+    os.environ["JOBFLOW_CONFIG_FILE"] = "/some/not/existing/path"
 
     from jobflow import SETTINGS
 


### PR DESCRIPTION
## Summary

Add functionalities to modify the list of Jobs/Flows in a Flow and prevent direct changes to it.  
`jobs` in `Flow` is a private tuple and should only be modified by the `add_jobs`, `remove_jobs` methods. Also `output` undergoes checks if it gets modified outside the `__init__` to avoid missing references.

I also changed one test of the settings since it was always picking my ~/.jobflows.yaml file and always failing locally.