### PR TITLE
Add job and flow update functions

### DIFF
--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -1,6 +1,26 @@
 Change log
 ==========
 
+Unreleased
+----------
+
+New features:
+
+- New ``update_metadata`` function for updating the metadata of jobs and flows.
+- New ``update_config`` function for updating the config (included manager_config) of
+  jobs and flows.
+- New ``DIRECTORY_FORMAT`` option in JobflowSettings for controlling the date time format
+  used to create new directories.
+- New functions for adding and removing jobs from a flow. The ``Job.jobs`` list is no
+  longer mutable (@gpetretto).
+- New ``Job.hosts`` attribute that stores a list of all host Flows. This captures the
+  nested nature of flows with the outer flow always first in the list (@gpetretto).
+
+Bug fixes:
+
+- OutputReferences are no longer iterable.
+- Docstring clarifications (@utf, @mjwen).
+
 v0.1.7
 ------
 

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -349,9 +349,11 @@ class Flow(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the job name.
+            A filter for the job name. Only jobs with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a job with the name "adder".
         function_filter
-            Only filter matching functions.
+            A filter for the job function. Only jobs with a matching function will be
+            updated.
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
@@ -404,10 +406,11 @@ class Flow(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the Maker name.
+            A filter for the Maker name. Only Makers with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a Maker with the name "adder".
         class_filter
-            A filter for the maker class. Note the class filter will match any
-            subclasses.
+            A filter for the maker class. Only Makers with a matching class will be
+            updated. Note the class filter will match any subclasses.
         nested
             Whether to apply the updates to Maker objects that are themselves kwargs
             of Maker, job, or flow objects. See examples for more details.
@@ -520,9 +523,11 @@ class Flow(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the job name.
+            A filter for the job name. Only jobs with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a job with the name "adder".
         function_filter
-            Only filter matching functions.
+            A filter for the job function. Only jobs with a matching function will be
+            updated.
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
@@ -568,9 +573,11 @@ class Flow(MSONable):
         config
             A JobConfig object or a dict with containing the attributes to update.
         name_filter
-            A filter for the job name.
+            A filter for the job name. Only jobs with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a job with the name "adder".
         function_filter
-            Only filter matching functions.
+            A filter for the job function. Only jobs with a matching function will be
+            updated.
         attributes :
             Which attributes of the job config to set. Can be specified as one or more
             attributes specified by their name.

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -503,6 +503,116 @@ class Flow(MSONable):
         for job in self.jobs:
             job.append_name(append_str, prepend=prepend)
 
+    def update_metadata(
+        self,
+        update: dict[str, Any],
+        name_filter: str | None = None,
+        function_filter: Callable | None = None,
+        dict_mod: bool = False,
+    ):
+        """
+        Update the metadata of all Jobs in the Flow.
+
+        Note that updates will be applied to jobs in nested Flow.
+
+        Parameters
+        ----------
+        update
+            The updates to apply.
+        name_filter
+            A filter for the job name.
+        function_filter
+            Only filter matching functions.
+        dict_mod
+            Use the dict mod language to apply updates. See :obj:`.DictMods` for more
+            details.
+
+        Examples
+        --------
+        Consider a flow containing two jobs.
+
+        >>> from jobflow import job, Flow
+        >>> @job
+        ... def add(a, b):
+        ...     return a + b
+        >>> add_job1 = add(5, 6)
+        >>> add_job2 = add(6, 7)
+        >>> flow = Flow([add_job1, add_job2])
+
+        The ``metadata`` of both jobs could be updated as follows:
+
+        >>> flow.update_metadata({"tag": "addition_job"})
+        """
+        for job in self.jobs:
+            job.update_metadata(
+                update,
+                name_filter=name_filter,
+                function_filter=function_filter,
+                dict_mod=dict_mod,
+            )
+
+    def update_config(
+        self,
+        config: jobflow.JobConfig | dict,
+        name_filter: str = None,
+        function_filter: Callable = None,
+        attributes: list[str] | str = None,
+    ):
+        """
+        Update the job config of all Jobs in the Flow.
+
+        Note that updates will be applied to jobs in nested Flow.
+
+        Parameters
+        ----------
+        config
+            A JobConfig object or a dict with containing the attributes to update.
+        name_filter
+            A filter for the job name.
+        function_filter
+            Only filter matching functions.
+        attributes :
+            Which attributes of the job config to set. Can be specified as one or more
+            attributes specified by their name.
+
+        Examples
+        --------
+        Consider a flow containing two jobs.
+
+        >>> from jobflow import job, Flow
+        >>> @job
+        ... def add(a, b):
+        ...     return a + b
+        >>> add_job1 = add(5, 6)
+        >>> add_job2 = add(6, 7)
+        >>> flow = Flow([add_job1, add_job2])
+
+        The ``config`` of both jobs could be updated as follows:
+        >>> new_config = JobConfig(
+        ...    manager_config={"_fworker": "myfworker"}, resolve_references=False
+        ... )
+        >>> flow.update_config(new_config)
+
+        To only update specific attributes, the ``attributes`` argument can be set. For
+        example, the following will only update the "manager_config" attribute of the
+        jobs' config.
+
+        >>> flow.update_config(new_config, attributes="manager_config")
+
+        Alternatively, the config can be specified as a dictionary with keys that are
+        attributes of the JobConfig object. This allows you to specify updates without
+        having to create a completely new JobConfig object. For example:
+
+        >>> flow.update_config({"manager_config": {"_fworker": "myfworker"}})
+        """
+        for job in self.jobs:
+            job.update_config(
+                config,
+                name_filter=name_filter,
+                function_filter=function_filter,
+                attributes=attributes,
+            )
+
     def add_hosts_uuids(
         self, hosts_uuids: str | list[str] | None = None, prepend: bool = False
     ):

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -932,6 +932,13 @@ class Job(MSONable):
             # convert dict specification to a JobConfig but set the attributes accordingly
             if attributes is None:
                 attributes = list(config.keys())
+
+            attributes = [attributes] if isinstance(attributes, str) else attributes
+            if not set(attributes).issubset(set(config.keys())):
+                raise ValueError(
+                    "Specified attributes include a key that is not present in the config"
+                    " dictionary."
+                )
             config = JobConfig(**config)
 
         if attributes is None:

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -656,9 +656,11 @@ class Job(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the job name.
+            A filter for the job name. Only jobs with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a job with the name "adder".
         function_filter
-            Only filter matching functions.
+            A filter for the job function. Only jobs with a matching function will be
+            updated.
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
@@ -711,10 +713,11 @@ class Job(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the Maker name.
+            A filter for the Maker name. Only Makers with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a Maker with the name "adder".
         class_filter
-            A filter for the maker class. Note the class filter will match any
-            subclasses.
+            A filter for the maker class. Only Makers with a matching class will be
+            updated. Note the class filter will match any subclasses.
         nested
             Whether to apply the updates to Maker objects that are themselves kwargs
             of Maker, job, or flow objects. See examples for more details.
@@ -841,9 +844,11 @@ class Job(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the job name.
+            A filter for the job name. Only jobs with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a job with the name "adder".
         function_filter
-            Only filter matching functions.
+            A filter for the job function. Only jobs with a matching function will be
+            updated.
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
@@ -881,9 +886,11 @@ class Job(MSONable):
         config
             A JobConfig object or a dict with containing the attributes to update.
         name_filter
-            A filter for the job name.
+            A filter for the job name. Only jobs with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a job with the name "adder".
         function_filter
-            Only filter matching functions.
+            A filter for the job function. Only jobs with a matching function will be
+            updated.
         attributes :
             Which attributes of the job config to set. Can be specified as one or more
             attributes specified by their name.

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -149,10 +149,11 @@ class Maker(MSONable):
         update
             The updates to apply.
         name_filter
-            A filter for the Maker name.
+            A filter for the Maker name. Only Makers with a matching name will be updated.
+            Includes partial matches, e.g. "ad" will match a Maker with the name "adder".
         class_filter
-            A filter for the maker class. Note the class filter will match any
-            subclasses.
+            A filter for the maker class. Only Makers with a matching class will be
+            updated. Note the class filter will match any subclasses.
         nested
             Whether to apply the updates to Maker objects that are themselves kwargs
             of a Maker object. See examples for more details.

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -253,6 +253,10 @@ class OutputReference(MSONable):
         else:
             raise TypeError("OutputReference objects are immutable")
 
+    def __iter__(self):
+        """Make sure OutputReference is not iterable."""
+        raise TypeError("OutputReference objects are not iterable")
+
     def __setitem__(self, index, val):
         """Set item."""
         # Setting items via indexing is not allowed.

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -52,7 +52,7 @@ def run_locally(
 
     from monty.os import cd
 
-    from jobflow import SETTINGS, Job, initialize_logger
+    from jobflow import SETTINGS, initialize_logger
     from jobflow.core.flow import get_flow
     from jobflow.core.reference import OnMissing
 
@@ -139,22 +139,13 @@ def run_locally(
             return root_dir
 
     def _run(root_flow):
-        if isinstance(root_flow, Job):
+        job: jobflow.Job
+        for job, parents in root_flow.iterflow():
             job_dir = _get_job_dir()
             with cd(job_dir):
-                response = _run_job(root_flow, [])
-
+                response = _run_job(job, parents)
             if response is False:
                 return False
-
-        else:
-            job: jobflow.Job
-            for job, parents in root_flow.iterflow():
-                job_dir = _get_job_dir()
-                with cd(job_dir):
-                    response = _run_job(job, parents)
-                if response is False:
-                    return False
 
         return True if response is not None else False
 

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -131,7 +131,7 @@ def run_locally(
 
     def _get_job_dir():
         if create_folders:
-            time_now = datetime.utcnow().strftime("%Y-%m-%d-%H-%M-%S-%f")
+            time_now = datetime.utcnow().strftime(SETTINGS.DIRECTORY_FORMAT)
             job_dir = root_dir / f"job_{time_now}-{randint(10000, 99999)}"
             job_dir.mkdir()
             return job_dir

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -98,6 +98,10 @@ class JobflowSettings(BaseSettings):
         "See the :obj:`JobflowSettings` docstring for more details on the "
         "accepted formats.",
     )
+    DIRECTORY_FORMAT: str = Field(
+        "%Y-%m-%d-%H-%M-%S-%f",
+        description="Date stamp format used to create directories",
+    )
 
     class Config:
         """Pydantic config settings."""

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -20,6 +20,7 @@ def get_test_flow():
 
     add_job = Job(add, function_args=(1, 2))
     div_job = Job(div, function_args=(add_job.output,), function_kwargs={"b": 3})
+    div_job.metadata = {"b": 3}
     return Flow([add_job, div_job])
 
 
@@ -696,3 +697,29 @@ def test_set_output():
 
     with pytest.raises(ValueError):
         flow.output = [add_job3.output]
+
+
+def test_update_metadata():
+    # test no filter
+    flow = get_test_flow()
+    flow.update_metadata({"b": 5})
+    assert flow.jobs[0].metadata["b"] == 5
+    assert flow.jobs[1].metadata["b"] == 5
+
+    # test name filter
+    flow = get_test_flow()
+    flow.update_metadata({"b": 5}, name_filter="div")
+    assert "b" not in flow.jobs[0].metadata
+    assert flow.jobs[1].metadata["b"] == 5
+
+    # test function filter
+    flow = get_test_flow()
+    flow.update_metadata({"b": 5}, function_filter=div)
+    assert "b" not in flow.jobs[0].metadata
+    assert flow.jobs[1].metadata["b"] == 5
+
+    # test dict mod
+    flow = get_test_flow()
+    flow.update_metadata({"_inc": {"b": 5}}, function_filter=div, dict_mod=True)
+    assert "b" not in flow.jobs[0].metadata
+    assert flow.jobs[1].metadata["b"] == 8

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -723,3 +723,39 @@ def test_update_metadata():
     flow.update_metadata({"_inc": {"b": 5}}, function_filter=div, dict_mod=True)
     assert "b" not in flow.jobs[0].metadata
     assert flow.jobs[1].metadata["b"] == 8
+
+
+def test_update_config():
+    from jobflow import JobConfig
+
+    new_config = JobConfig(
+        resolve_references=False,
+        manager_config={"a": "b"},
+        pass_manager_config=False,
+    )
+
+    # test no filter
+    flow = get_test_flow()
+    flow.update_config(new_config)
+    assert flow.jobs[0].config == new_config
+    assert flow.jobs[1].config == new_config
+
+    # test name filter
+    flow = get_test_flow()
+    flow.update_config(new_config, name_filter="div")
+    assert flow.jobs[0].config != new_config
+    assert flow.jobs[1].config == new_config
+
+    # test function filter
+    flow = get_test_flow()
+    flow.update_config(new_config, function_filter=div)
+    assert flow.jobs[0].config != new_config
+    assert flow.jobs[1].config == new_config
+
+    # test attributes
+    flow = get_test_flow()
+    flow.update_config(new_config, function_filter=div, attributes=["manager_config"])
+    assert flow.jobs[0].config.manager_config == {}
+    assert flow.jobs[0].config.resolve_references
+    assert flow.jobs[1].config.manager_config == {"a": "b"}
+    assert flow.jobs[1].config.resolve_references

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -603,6 +603,34 @@ def test_get_flow():
     get_flow([job1, job2])
 
 
+def test_add_hosts_uuids():
+    from jobflow.core.flow import Flow
+
+    add_job1 = get_test_job()
+    add_job2 = get_test_job()
+
+    # test adding host id again (automatically added once on job creation)
+    flow = Flow([add_job1, add_job2])
+    flow.add_hosts_uuids()
+    assert add_job1.hosts == [flow.uuid, flow.uuid]
+    assert add_job2.hosts == [flow.uuid, flow.uuid]
+
+    # test appending specific uuid
+    flow = Flow([get_test_job()])
+    flow.add_hosts_uuids("abc")
+    assert flow.jobs[0].hosts == [flow.uuid, "abc"]
+
+    # test appending several uuid
+    flow = Flow([get_test_job()])
+    flow.add_hosts_uuids(["abc", "xyz"])
+    assert flow.jobs[0].hosts == [flow.uuid, "abc", "xyz"]
+
+    # test prepending specific uuid
+    flow = Flow([get_test_job()])
+    flow.add_hosts_uuids("abc", prepend=True)
+    assert flow.jobs[0].hosts == ["abc", flow.uuid]
+
+
 def test_hosts():
     from jobflow.core.flow import Flow
 

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -982,3 +982,38 @@ def test_hosts(memory_jobstore):
     test_job.run(memory_jobstore)
     result = memory_jobstore.query_one({"uuid": test_job.uuid})
     assert result["hosts"] == ["09876", "12345", "67890"]
+
+
+def test_update_metadata():
+    from jobflow import Job
+
+    # test no filter
+    test_job = Job(add, function_args=(1,))
+    test_job.update_metadata({"b": 5})
+    assert test_job.metadata["b"] == 5
+
+    # test name filter
+    test_job = Job(add, function_args=(1,))
+    test_job.update_metadata({"b": 5}, name_filter="add")
+    assert test_job.metadata["b"] == 5
+
+    test_job = Job(add, function_args=(1,))
+    test_job.metadata = {"b": 2}
+    test_job.update_metadata({"b": 5}, name_filter="div")
+    assert test_job.metadata["b"] == 2
+
+    # test function filter
+    test_job = Job(add, function_args=(1,))
+    test_job.update_metadata({"b": 5}, function_filter=add)
+    assert test_job.metadata["b"] == 5
+
+    test_job = Job(add, function_args=(1,))
+    test_job.metadata = {"b": 2}
+    test_job.update_metadata({"b": 5}, function_filter=list)
+    assert test_job.metadata["b"] == 2
+
+    # test dict mod
+    test_job = Job(add, function_args=(1,))
+    test_job.metadata = {"b": 2}
+    test_job.update_metadata({"_inc": {"b": 5}}, dict_mod=True)
+    assert test_job.metadata["b"] == 7

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -1017,3 +1017,90 @@ def test_update_metadata():
     test_job.metadata = {"b": 2}
     test_job.update_metadata({"_inc": {"b": 5}}, dict_mod=True)
     assert test_job.metadata["b"] == 7
+
+
+def test_update_config():
+    from jobflow import Job, JobConfig
+
+    new_config = JobConfig(
+        resolve_references=False,
+        manager_config={"a": "b"},
+        pass_manager_config=False,
+    )
+    new_config_dict = {
+        "resolve_references": False,
+        "manager_config": {"a": "b"},
+        "pass_manager_config": False,
+    }
+
+    # test no filter
+    test_job = Job(add)
+    test_job.update_config(new_config)
+    assert test_job.config == new_config
+
+    # test name filter
+    test_job = Job(add)
+    test_job.update_config(new_config, name_filter="add")
+    assert test_job.config == new_config
+
+    test_job = Job(add)
+    test_job.update_config(new_config, name_filter="div")
+    assert test_job.config != new_config
+
+    # test function filter
+    test_job = Job(add)
+    test_job.update_config(new_config, function_filter=add)
+    assert test_job.config == new_config
+
+    test_job = Job(add)
+    test_job.update_config(new_config, function_filter=list)
+    assert test_job.config != new_config
+
+    # test attributes
+    test_job = Job(add)
+    test_job.update_config(new_config, attributes="manager_config")
+    assert test_job.config.manager_config == {"a": "b"}
+    assert test_job.config.resolve_references
+
+    test_job = Job(add)
+    test_job.update_config(new_config, attributes=["manager_config"])
+    assert test_job.config.manager_config == {"a": "b"}
+    assert test_job.config.resolve_references
+
+    test_job = Job(add)
+    test_job.update_config(
+        new_config, attributes=["manager_config", "resolve_references"]
+    )
+    assert test_job.config.manager_config == {"a": "b"}
+    assert not test_job.config.resolve_references
+    assert test_job.config.pass_manager_config
+
+    with pytest.raises(ValueError):
+        test_job.update_config(new_config, attributes="abc_xyz")
+
+    # test dictionary config updates
+    test_job = Job(add)
+    test_job.update_config(new_config_dict)
+    assert test_job.config == new_config
+
+    # test dict with attributes
+    test_job = Job(add)
+    test_job.update_config(new_config_dict, attributes="manager_config")
+    assert test_job.config.manager_config == {"a": "b"}
+    assert test_job.config.resolve_references
+
+    test_job = Job(add)
+    test_job.update_config(new_config_dict, attributes=["manager_config"])
+    assert test_job.config.manager_config == {"a": "b"}
+    assert test_job.config.resolve_references
+
+    test_job = Job(add)
+    test_job.update_config(
+        new_config_dict, attributes=["manager_config", "resolve_references"]
+    )
+    assert test_job.config.manager_config == {"a": "b"}
+    assert not test_job.config.resolve_references
+    assert test_job.config.pass_manager_config
+
+    with pytest.raises(ValueError):
+        test_job.update_config(new_config_dict, attributes="abc_xyz")

--- a/tests/core/test_reference.py
+++ b/tests/core/test_reference.py
@@ -463,3 +463,16 @@ def test_reference_in_output(memory_jobstore):
     assert ref1.resolve(memory_jobstore, on_missing=OnMissing.PASS) == ref2
     with pytest.raises(ValueError):
         ref1.resolve(memory_jobstore, on_missing=OnMissing.ERROR)
+
+
+def test_not_iterable():
+    from jobflow.core.reference import OutputReference
+
+    ref = OutputReference("12345")
+
+    with pytest.raises(TypeError):
+        next(ref)
+
+    with pytest.raises(TypeError):
+        for _ in ref:
+            pass


### PR DESCRIPTION
## Summary

New features:
- Added an `update_metadata` function for updating the metadata of jobs and flows (Fixes #115).
- Added an `update_config` function for updating the config (included manager_config) of jobs and flows (Addresses #73).
- Added the `DIRECTORY_FORMAT` option in settings for controlling the date time format used to create new directories (Fixes #128).

Bug fixes:
- OutputReferences are no longer iterable (Fixes #105).
- Docstring clarifications (Fixes #114).