### PR TITLE
searchable fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
             "FireWorks==2.0.3",
             "matplotlib==3.5.2",
             "pydot==1.4.2",
+            "moto==3.1.1",
         ],
         "dev": ["pre-commit>=2.12.1"],
         "vis": ["matplotlib", "pydot"],

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -64,7 +64,8 @@ class JobStore(Store):
         self.docs_store.key = "uuid"
         for additional_store in self.additional_stores.values():
             additional_store.key = "blob_uuid"
-            additional_store.searchable_fields.extend(["job_uuid", "job_index"])
+            if hasattr(additional_store, "searchable_fields"):
+                additional_store.searchable_fields.extend(["job_uuid", "job_index"])
 
         if save is None or save is False:
             save = {}

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -64,8 +64,7 @@ class JobStore(Store):
         self.docs_store.key = "uuid"
         for additional_store in self.additional_stores.values():
             additional_store.key = "blob_uuid"
-        for additional_store in self.additional_stores.values():
-            additional_store.searchable_fields = ["job_uuid", "job_index"]
+            additional_store.searchable_fields.extend(["job_uuid", "job_index"])
 
         if save is None or save is False:
             save = {}

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -64,6 +64,8 @@ class JobStore(Store):
         self.docs_store.key = "uuid"
         for additional_store in self.additional_stores.values():
             additional_store.key = "blob_uuid"
+        for additional_store in self.additional_stores.values():
+            additional_store.searchable_fields = ["job_uuid", "job_index"]
 
         if save is None or save is False:
             save = {}


### PR DESCRIPTION
## Make sure that the "job_uuid" and "job_index" can be searched on

Currently, the "job_uuid" is not stored in the index store of the S3Store.
Which means they are not searchable even though they are in the query results.

This should fix that behavior.