### PR TITLE
update_kwargs patch

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -785,7 +785,6 @@ class Job(MSONable):
                 nested=nested,
                 dict_mod=dict_mod,
             )
-            print(">> ", maker)
             setattr(self, "function", getattr(maker, self.function.__name__))
         elif nested:
             # also look for makers in job args and kwargs

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -785,6 +785,7 @@ class Job(MSONable):
                 nested=nested,
                 dict_mod=dict_mod,
             )
+            print(">> ", maker)
             setattr(self, "function", getattr(maker, self.function.__name__))
         elif nested:
             # also look for makers in job args and kwargs

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -219,6 +219,7 @@ class Maker(MSONable):
                 apply_mod(update, d)
             else:
                 d.update(update)
+            print(d)
             return MontyDecoder().process_decoded(d)
 
         return recursive_call(
@@ -307,4 +308,5 @@ def recursive_call(
             else:
                 func(nested_class)
     if update:
-        return MontyDecoder().process_decoded(d)
+        print("nested_class", nested_class)
+        return nested_class

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -244,7 +244,7 @@ class Maker(MSONable):
                         update,
                         name_filter=name_filter,
                         class_filter=class_filter,
-                        nested=nested,
+                        nested=False,
                         dict_mod=dict_mod,
                     )
 

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -295,8 +295,6 @@ def recursive_call(
         if len(location) == 0:
             continue
         nested_class = MontyDecoder().process_decoded(get(d, list(location)))
-        # print("nested_class 0", get(d, list(location)))
-        # print("nested_class 1", type(MontyDecoder().process_decoded(d)))
         if _filter(nested_class):
             # either update or call the function on the nested Maker
             modified_class = func(nested_class)
@@ -308,7 +306,7 @@ def recursive_call(
             # update the serialized maker with the new kwarg
             set_(d, list(location), modified_class.as_dict())
 
-    # the top level must be processed separately since it's constructor
+    # the top level must be processed separately since its constructor
     # might not be discoverable by MontyDecoder (kinda hacky)
     new_obj = obj.from_dict(d)
     if _filter(obj):

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -306,4 +306,5 @@ def recursive_call(
                     set_(d, list(location), func(nested_class).as_dict())
             else:
                 func(nested_class)
-    return MontyDecoder().process_decoded(d)
+    if update:
+        return MontyDecoder().process_decoded(d)

--- a/src/jobflow/core/maker.py
+++ b/src/jobflow/core/maker.py
@@ -213,7 +213,7 @@ class Maker(MSONable):
         from jobflow.utils.dict_mods import apply_mod
 
         def _update_kwargs_func(maker: Maker):
-            # if we get to here then we pass all the filters
+            # Update the kwargs of the maker
             d = maker.as_dict()
             if dict_mod:
                 apply_mod(update, d)
@@ -244,11 +244,12 @@ def recursive_call(
     Parameters
     ----------
     obj
-        The object to call the function on.
+        The Maker object to call the function on.
     func
-        The function to call.
+        The function to call a Maker object, if it matches the filters.
+        If the ``update`` is True, the function must return a new Maker object.
     update
-        Whether to update the object in place.
+        Whether to update the Maker object in place.
     name_filter
         A filter for the Maker name. Only Makers with a matching name will be updated.
         Includes partial matches, e.g. "ad" will match a Maker with the name "adder".
@@ -258,7 +259,6 @@ def recursive_call(
     nested
         Whether to apply the updates to Maker objects that are themselves kwargs
         of a Maker object. See examples for more details.
-
     """
     from pydash import get, set_
 


### PR DESCRIPTION
# Reworked update_kwargs,

This makes checking and validating maker parameters for complex makers much easier by recycling (with some modification) the code used for update_kwargs.

- Created a general function that can update or validate makers.
- The `recursive_call` function does not actually need to be recursive since the location found by `find_key` already contains all the objects that need to be worked on.
- We just have to reverse sort them by length to make sure we work on the deepest objects first.
- Then we can call a general function on all the Makers in the filter and update them if desired.
- The fact that `location` is sorted will make sure the updates are properly propagated up the chain.

The original PR message was for a smaller fix.
> ## Prevent extras calls to update_kwargs
> 
> I think if `update_kwargs` is called with `nested=True` it will already go in and look for all the makers starting from the top level.
> So when you call `update_kwargs` recursively it does not need `nested=True` anymore.

