### PR TITLE
Added default for additional_stores in the settings.

### DIFF
--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -328,7 +328,13 @@ class JobStore(Store):
         self.docs_store.update(dict_docs, key=key)
 
         for store_name, blobs in blob_data.items():
-            store = self.additional_stores.get(store_name, None)
+            # Here we use a try/except with a self.additional_stores[store_name]
+            # instead of self.additional_store.get(store_name, None) to allow
+            # for additional_stores to be a defaultdict with a MemoryStore's default.
+            try:
+                store = self.additional_stores[store_name]
+            except KeyError:
+                store = None
 
             if store is None:
                 raise ValueError(f"Unrecognised additional store name: {store_name}")

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,5 +1,6 @@
 """Settings for jobflow."""
 
+from collections import defaultdict
 from pathlib import Path
 
 from maggma.stores import MemoryStore
@@ -10,6 +11,17 @@ from jobflow import JobStore
 DEFAULT_CONFIG_FILE_PATH = Path("~/.jobflow.yaml").expanduser().as_posix()
 
 __all__ = ["JobflowSettings"]
+
+
+def _default_additional_store():
+    """Create a default MemoryStore and connect it.
+
+    This is a private function used for the additional_stores in
+    the default JOB_STORE.
+    """
+    mem_store = MemoryStore()
+    mem_store.connect()
+    return mem_store
 
 
 class JobflowSettings(BaseSettings):
@@ -93,7 +105,10 @@ class JobflowSettings(BaseSettings):
 
     # general settings
     JOB_STORE: JobStore = Field(
-        default_factory=lambda: JobStore(MemoryStore()),
+        default_factory=lambda: JobStore(
+            MemoryStore(),
+            additional_stores=defaultdict(lambda: _default_additional_store()),
+        ),
         description="Default JobStore to use when running locally or using FireWorks. "
         "See the :obj:`JobflowSettings` docstring for more details on the "
         "accepted formats.",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,11 @@ def test_settings_init():
 
     # assert default job store initialised correctly
     assert isinstance(SETTINGS.JOB_STORE.docs_store, MemoryStore)
+    assert len(SETTINGS.JOB_STORE.additional_stores) == 0
+    data_store = SETTINGS.JOB_STORE.additional_stores["data"]
+    assert len(SETTINGS.JOB_STORE.additional_stores) == 1
+    assert isinstance(data_store, MemoryStore)
+    assert data_store is SETTINGS.JOB_STORE.additional_stores["data"]
 
 
 def test_settings_object(clean_dir, test_data):


### PR DESCRIPTION
One of the main advantages of jobflow is to be able to start running a workflow (Flow) almost without any configuration, at least in terms of databases to set up (well you still have to configure e.g. vasp, pseudos, ... for atomate2). In atomate2, additional stores are used in the JobStore (e.g. "data"). The default JOB_STORE used a MemoryStore for the "main" store (the JobStore.docs_store) but did not set any default for the additional stores. These additional stores of course are not known in advance (their keys in the dict). For atomate2, it uses "data" but other implementations may use other key(s) for these additional stores. This PR solves this by using a defaultdict with a factory function (lambda) that returns a MemoryStore the first time it is accessed.

## Summary

Include a summary of major changes in bullet points:

- Modified the default JobStore so that it handles additional_stores with on-the-fly generated MemoryStore's
