### PR TITLE
Delayed updates to config and metadata

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -512,6 +512,7 @@ class Flow(MSONable):
         name_filter: str | None = None,
         function_filter: Callable | None = None,
         dict_mod: bool = False,
+        dynamic: bool = True,
     ):
         """
         Update the metadata of all Jobs in the Flow.
@@ -531,6 +532,8 @@ class Flow(MSONable):
         dict_mod
             Use the dict mod language to apply updates. See :obj:`.DictMods` for more
             details.
+        dynamic
+            The updates will be propagated to Jobs/Flows dynamically generated at runtime.
 
         Examples
         --------
@@ -554,6 +557,7 @@ class Flow(MSONable):
                 name_filter=name_filter,
                 function_filter=function_filter,
                 dict_mod=dict_mod,
+                dynamic=dynamic,
             )
 
     def update_config(
@@ -562,6 +566,7 @@ class Flow(MSONable):
         name_filter: str = None,
         function_filter: Callable = None,
         attributes: list[str] | str = None,
+        dynamic: bool = True,
     ):
         """
         Update the job config of all Jobs in the Flow.
@@ -581,6 +586,8 @@ class Flow(MSONable):
         attributes :
             Which attributes of the job config to set. Can be specified as one or more
             attributes specified by their name.
+        dynamic
+            The updates will be propagated to Jobs/Flows dynamically generated at runtime.
 
         Examples
         --------
@@ -619,6 +626,7 @@ class Flow(MSONable):
                 name_filter=name_filter,
                 function_filter=function_filter,
                 attributes=attributes,
+                dynamic=dynamic,
             )
 
     def add_hosts_uuids(

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -875,6 +875,29 @@ class Job(MSONable):
             details.
         dynamic
             The updates will be propagated to Jobs/Flows dynamically generated at runtime.
+
+        Examples
+        --------
+        Consider a simple job that makes use of a :obj:`Maker` to generate additional jobs
+        at runtime (see :obj:`Response` options for more details):
+
+        >>> @job
+        ... def use_maker(maker):
+        ...     return Response(replace=maker.make())
+
+        Calling `update_metadata` with `dynamic` set to `True` (the default)
+
+        >>> test_job = use_maker(ExampleMaker())
+        ... test_job.update_metadata({"example": 1}, dynamic=True)
+
+        will not only set the `example` metadata to the `test_job`, but also to all the
+        new Jobs that will be generated at runtime by the ExampleMaker.
+
+        `update_metadata` can be called multiple times with different `name_filter` or
+        `function_filter` to control which Jobs will be updated.
+
+        At variance, if `dynamic` is set to `False` the `example` metadata will only be
+        added to the `test_job` and not to the generated Jobs.
         """
         from jobflow.utils.dict_mods import apply_mod
 
@@ -964,6 +987,27 @@ class Job(MSONable):
         having to create a completely new JobConfig object. For example:
 
         >>> add_job.update_config({"manager_config": {"_fworker": "myfworker"}})
+
+        Consider instead a simple job that makes use of a :obj:`Maker` to generate
+        additional jobs at runtime (see :obj:`Response` options for more details):
+
+        >>> @job
+        ... def use_maker(maker):
+        ...     return Response(replace=maker.make())
+
+        Calling `update_config` with `dynamic` set to `True` (the default)
+
+        >>> test_job = use_maker(ExampleMaker())
+        ... test_job.update_config({"manager_config": {"_fworker": "myfworker"}})
+
+        will not only set the `manager_config` to the `test_job`, but also to all the
+        new Jobs that will be generated at runtime by the ExampleMaker.
+
+        `update_config` can be called multiple times with different `name_filter` or
+        `function_filter` to control which Jobs will be updated.
+
+        At variance, if `dynamic` is set to `False` the `manager_config` option will
+        only be set for the `test_job` and not for the generated Jobs.
         """
         if dynamic:
             dict_input = dict(

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -599,6 +599,7 @@ class Job(MSONable):
             "completed_at": datetime.now().isoformat(),
             "metadata": self.metadata,
             "hosts": self.hosts,
+            "name": self.name,
         }
         store.update(data, key=["uuid", "index"], save=save)
 

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -984,13 +984,19 @@ def test_hosts(memory_jobstore):
     assert result["hosts"] == ["09876", "12345", "67890"]
 
 
-def test_update_metadata():
-    from jobflow import Job
+def test_update_metadata(memory_jobstore):
+    from dataclasses import dataclass
+
+    from jobflow import Job, Maker, Response, job
 
     # test no filter
     test_job = Job(add, function_args=(1,))
     test_job.update_metadata({"b": 5})
     assert test_job.metadata["b"] == 5
+    assert len(test_job.metadata_updates) == 1
+    test_job.update_metadata({"c": 6}, dynamic=False)
+    assert test_job.metadata["c"] == 6
+    assert len(test_job.metadata_updates) == 1
 
     # test name filter
     test_job = Job(add, function_args=(1,))
@@ -1012,15 +1018,88 @@ def test_update_metadata():
     test_job.update_metadata({"b": 5}, function_filter=list)
     assert test_job.metadata["b"] == 2
 
+    # test function filter with wrapped job functions
+    @job
+    def add_wrapped(a, b):
+        return a + b
+
+    class A:
+        @classmethod
+        @job
+        def cmj_wrapped(cls, a, b):
+            return a + b
+
+        @staticmethod
+        @job
+        def smj_wrapped(a, b):
+            return a + b
+
+        @job
+        @classmethod
+        def jcm_wrapped(cls, a, b):
+            return a + b
+
+        @job
+        @staticmethod
+        def jsm_wrapped(a, b):
+            return a + b
+
+    test_job = add_wrapped(1, 2)
+    test_job.update_metadata({"b": 5}, function_filter=add_wrapped)
+    assert test_job.metadata["b"] == 5
+
+    test_job = add_wrapped(1, 2)
+    test_job.metadata = {"b": 2}
+    test_job.update_metadata({"b": 5}, function_filter=add)
+    assert test_job.metadata["b"] == 2
+
+    test_job = A.cmj_wrapped(1, 2)
+    test_job.update_metadata({"b": 5}, function_filter=A.cmj_wrapped)
+    assert test_job.metadata["b"] == 5
+
+    test_job = A.smj_wrapped(1, 2)
+    test_job.update_metadata({"b": 5}, function_filter=A.smj_wrapped)
+    assert test_job.metadata["b"] == 5
+
+    test_job = A.jcm_wrapped(1, 2)
+    test_job.update_metadata({"b": 5}, function_filter=A.jcm_wrapped)
+    assert test_job.metadata["b"] == 5
+
+    test_job = A.jsm_wrapped(1, 2)
+    test_job.update_metadata({"b": 5}, function_filter=A.jsm_wrapped)
+    assert test_job.metadata["b"] == 5
+
     # test dict mod
     test_job = Job(add, function_args=(1,))
     test_job.metadata = {"b": 2}
     test_job.update_metadata({"_inc": {"b": 5}}, dict_mod=True)
     assert test_job.metadata["b"] == 7
 
+    # test applied dynamic updates
+    @dataclass
+    class TestMaker(Maker):
+        name = "test"
 
-def test_update_config():
-    from jobflow import Job, JobConfig
+        @job
+        def make(self, a, b):
+            return a + b
+
+    @job
+    def use_maker(maker):
+        return Response(replace=maker.make())
+
+    test_job = use_maker(TestMaker())
+    test_job.name = "use"
+    test_job.update_metadata({"b": 2}, name_filter="test")
+    assert "b" not in test_job.metadata
+    response = test_job.run(memory_jobstore)
+    assert response.replace.jobs[0].metadata["b"] == 2
+
+
+def test_update_config(memory_jobstore):
+    from dataclasses import dataclass
+
+    from jobflow import Job, JobConfig, Maker, Response, job
 
     new_config = JobConfig(
         resolve_references=False,
@@ -1037,6 +1116,9 @@ def test_update_config():
     test_job = Job(add)
     test_job.update_config(new_config)
     assert test_job.config == new_config
+    assert len(test_job.config_updates) == 1
+    test_job.update_config(new_config, dynamic=False)
+    assert len(test_job.config_updates) == 1
 
     # test name filter
     test_job = Job(add)
@@ -1055,6 +1137,56 @@ def test_update_config():
     test_job = Job(add)
     test_job.update_config(new_config, function_filter=list)
     assert test_job.config != new_config
+
+    # test function filter with wrapped job functions
+    @job
+    def add_wrapped(a, b):
+        return a + b
+
+    class A:
+        @classmethod
+        @job
+        def cmj_wrapped(cls, a, b):
+            return a + b
+
+        @staticmethod
+        @job
+        def smj_wrapped(a, b):
+            return a + b
+
+        @job
+        @classmethod
+        def jcm_wrapped(cls, a, b):
+            return a + b
+
+        @job
+        @staticmethod
+        def jsm_wrapped(a, b):
+            return a + b
+
+    test_job = add_wrapped(1, 2)
+    test_job.update_config(new_config, function_filter=add_wrapped)
+    assert test_job.config == new_config
+
+    test_job = add_wrapped(1, 2)
+    test_job.update_config(new_config, function_filter=list)
+    assert test_job.config != new_config
+
+    test_job = A.cmj_wrapped(1, 2)
+    test_job.update_config(new_config, function_filter=A.cmj_wrapped)
+    assert test_job.config == new_config
+
+    test_job = A.smj_wrapped(1, 2)
+    test_job.update_config(new_config, function_filter=A.smj_wrapped)
+    assert test_job.config == new_config
+
+    test_job = A.jcm_wrapped(1, 2)
+    test_job.update_config(new_config, function_filter=A.jcm_wrapped)
+    assert test_job.config == new_config
+
+    test_job = A.jsm_wrapped(1, 2)
+    test_job.update_config(new_config, function_filter=A.jsm_wrapped)
+    assert test_job.config == new_config
 
     # test attributes
     test_job = Job(add)
@@ -1104,3 +1236,23 @@ def test_update_config():
 
     with pytest.raises(ValueError):
         test_job.update_config(new_config_dict, attributes="abc_xyz")
+
+    # test applied dynamic updates
+    @dataclass
+    class TestMaker(Maker):
+        name = "test"
+
+        @job
+        def make(self, a, b):
+            return a + b
+
+    @job
+    def use_maker(maker):
+        return Response(replace=maker.make())
+
+    test_job = use_maker(TestMaker())
+    test_job.name = "use"
+    test_job.update_config(new_config, name_filter="test")
+    assert test_job.config != new_config
+    response = test_job.run(memory_jobstore)
+    assert response.replace.jobs[0].config == new_config

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -1094,6 +1094,7 @@ def test_update_metadata(memory_jobstore):
     assert "b" not in test_job.metadata
     response = test_job.run(memory_jobstore)
     assert response.replace.jobs[0].metadata["b"] == 2
+    assert response.replace.jobs[0].metadata_updates[0]["update"] == {"b": 2}
 
 
 def test_update_config(memory_jobstore):
@@ -1256,3 +1257,4 @@ def test_update_config(memory_jobstore):
     assert test_job.config != new_config
     response = test_job.run(memory_jobstore)
     assert response.replace.jobs[0].config == new_config
+    assert response.replace.jobs[0].config_updates[0]["config"] == new_config


### PR DESCRIPTION
## Summary

Implementing delayed updates for config and metadata as discussed in #193 

Added job name in the stored job document.

Fixing few issues in the update_config/metadata:

- The `function_filter` was working only in the case of instantiated `Job`s and not for `@job` decorated functions. Switched to checking the wrapped functions. 
- The logic for `name_filter` was wrong in case of the job name is `None`. In principle the name is never `None`, but fixed it anyway


