### PR TITLE
[Bug Fix] Fixed nested data storage bug

### DIFF
--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -8,6 +8,7 @@ from maggma.core import Store
 from monty.json import MSONable
 
 from jobflow.core.reference import OnMissing
+from jobflow.utils.find import get_root_locations
 
 if typing.TYPE_CHECKING:
     from enum import Enum
@@ -303,7 +304,7 @@ class JobStore(Store):
                     for save_key in store_save:
                         locations.extend(find_key(doc, save_key, include_end=True))
 
-                    locations = _get_root_locations(locations)
+                    locations = get_root_locations(locations)
                     objects = [get(doc, list(loc)) for loc in locations]
                     object_map = {
                         tuple(k): o for k, o in zip(locations, objects) if o is not None
@@ -786,21 +787,3 @@ def _get_blob_info(obj: Any, store_name: str) -> dict[str, str]:
         "blob_uuid": suuid(),
         "store": store_name,
     }
-
-
-def _get_root_locations(locations):
-    """Get only the lowest level locations.
-
-    If a parent location is in the list, the child location is removed
-
-    Example usage:
-        >>> _get_root_locations([["a", "b"], ["a"], ["c", "d"]])
-        [["a"], ["c", "d"]]
-    """
-    sorted_locs = sorted(locations, key=lambda x: len(x))
-    root_locations = []
-    for loc in sorted_locs:
-        if any([loc[: len(rloc)] == rloc for rloc in root_locations]):
-            continue
-        root_locations.append(loc)
-    return root_locations

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -303,6 +303,7 @@ class JobStore(Store):
                     for save_key in store_save:
                         locations.extend(find_key(doc, save_key, include_end=True))
 
+                    locations = _get_root_locations(locations)
                     objects = [get(doc, list(loc)) for loc in locations]
                     object_map = {
                         tuple(k): o for k, o in zip(locations, objects) if o is not None
@@ -785,3 +786,21 @@ def _get_blob_info(obj: Any, store_name: str) -> dict[str, str]:
         "blob_uuid": suuid(),
         "store": store_name,
     }
+
+
+def _get_root_locations(locations):
+    """Get only the lowest level locations.
+
+    If a parent location is in the list, the child location is removed
+
+    Example usage:
+        >>> _get_root_locations([["a", "b"], ["a"], ["c", "d"]])
+        [["a"], ["c", "d"]]
+    """
+    sorted_locs = sorted(locations, key=lambda x: len(x))
+    root_locations = []
+    for loc in sorted_locs:
+        if any([loc[: len(rloc)] == rloc for rloc in root_locations]):
+            continue
+        root_locations.append(loc)
+    return root_locations

--- a/src/jobflow/utils/find.py
+++ b/src/jobflow/utils/find.py
@@ -220,3 +220,31 @@ def contains_flow_or_job(obj: Any) -> bool:
     locations += find_key_value(obj, "@class", "Job")
 
     return len(locations) > 0
+
+
+def get_root_locations(locations):
+    """Get only the lowest level locations.
+
+    If a parent location is in the list, the child location is removed
+
+    Parameters
+    ----------
+    locations : list[list]
+        A list of locations.
+
+    Returns
+    -------
+    list[list]
+        A list of locations with only the lowest level locations.
+
+    Example usage:
+        >>> _get_root_locations([["a", "b"], ["a"], ["c", "d"]])
+        [["a"], ["c", "d"]]
+    """
+    sorted_locs = sorted(locations, key=lambda x: len(x))
+    root_locations = []
+    for loc in sorted_locs:
+        if any([loc[: len(rloc)] == rloc for rloc in root_locations]):
+            continue
+        root_locations.append(loc)
+    return root_locations

--- a/src/jobflow/utils/find.py
+++ b/src/jobflow/utils/find.py
@@ -223,7 +223,7 @@ def contains_flow_or_job(obj: Any) -> bool:
 
 
 def get_root_locations(locations):
-    """Get only the lowest level locations.
+    """Filter for the the lowest level locations.
 
     If a parent location is in the list, the child location is removed
 

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -1,5 +1,7 @@
 import pytest
 
+from jobflow.core.store import JobStore
+
 
 @pytest.fixture
 def memory_store():
@@ -224,6 +226,28 @@ def test_data_update(memory_data_jobstore):
     assert data2 in data_fields
     assert data3 in data_fields
     assert None not in data_fields
+
+
+def test_nested_msonable(memory_data_jobstore):
+    from monty.json import MSONable
+
+    class Child(MSONable):
+        def __init__(self, x):
+            self.x = x
+
+    class Parent(MSONable):
+        def __init__(self, child):
+            self.child = child
+
+    parent = Parent(child=Child(x=5))
+    d = {"index": 1, "uuid": 1, "parent": parent}
+    memory_data_jobstore: JobStore
+    memory_data_jobstore.update(d, save={"data": [Parent, Child]})
+    ds = memory_data_jobstore.additional_stores["data"]
+    classes = ds.distinct("@class")
+    assert set(classes) == {
+        "Parent",
+    }
 
 
 def test_count(memory_jobstore):


### PR DESCRIPTION
## Summary

This should fix the following bug:
https://github.com/materialsproject/atomate2/issues/291

Currently, there is a problem when you serialize nested data when you have `Child` nested in `Parent`, both will get uploaded to the `additional_store`.  But I think you should ever only serialize the `Parent` in all but a few exceptional cases.
