### PR TITLE
Add `to_mermaid` function to covert flow to mermaid syntax

### DIFF
--- a/docs/tutorials/1-quickstart.ipynb
+++ b/docs/tutorials/1-quickstart.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "conservative-lithuania",
    "metadata": {
     "nbsphinx": "hidden"
@@ -86,7 +86,7 @@
     {
      "data": {
       "text/plain": [
-       "OutputReference(3bc98d5e-b593-4ad1-a409-cef9136bb835)"
+       "OutputReference(c923a1eb-af97-4a3e-9b19-c2ba36784177)"
       ]
      },
      "execution_count": 4,
@@ -158,7 +158,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALUAAACxCAYAAACCwvy/AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAM5klEQVR4nO3df2xT573H8c9zfGz8iwhDUmjSlJRC2jkmhStopQ4KaUGiHZcfRQMVonbdpIptqFeIljuudFGbfyJlgnRdpVZdpaXaFi2iQtxNyqaxNqijKk1SKYHGtCBIVFi6EStJiWMb++Q89480blNgg+LDKd98Xn85jp/j7xFvnRzbx0JprUEkieH2AESFxqhJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4phuDyCdUuo2Q6mn/B5PtccwZozZ9nBmbOy4rXWT1nrA7fkkUrygyRlKqaVBr3ePZduPLisr098pLg4ETRMpy0I8kUi/d/68Mg3jTynLqtdad7g9rySM2gFew9juM81926JR/6qKCmO6z3fZY0ayWRzu67Ob4/FM1rJ25Wz7NRdGFYlRF5jXMLYXTZu2r6GmJlgaDk/63T9HR/F0ayv+uGkTPMb4y5n+ZBK729pSFy9d2mVpPQfAfK11rQuji8EXigWklFrqM80rBn01peEwGmpqgj7T3Aeg1NkJpwZGXUBBr3fPtmjUf61BTygNh7E1GvWbSi1zaLQphe9+FIBS6mcAtgOY23rmDGaHQniwrAxjWuPXx4/jr319CHq92FhZOWndP0ZHsb+9HWeGhzE/EjFsrSsB9LixD5LwSF0YZxTwm5Xl5enaWAw//+ADDKbT+PPZs2j/7DP8cvVq/GLVKrx3/vykRQ3HjmF+JILfr1uH2qoqKKU8AOa5swtyMOoC0FofCJhmRVVJSWBFeTnKwmF8MjiIv507h/ULFqAkGMR0nw+b7703v+ZCKoVTQ0N4MhaD1+PBwpISzJsxA4ZSERd3RQSefhSAUupJBax7o7sbTSdOIG1ZuJjNYjCTQUkwmH/cbaFQ/vZgOo2w1wu/+eU/QcTvhwK8N3V4gXikvkFKqbkAfuU1jPd/WF2NAxs2oKKoCFprzPT7MZBK5R974Su3I34/krkcMpaVv28ok4EGcjdzfokY9Y0LAdA52z5+MpFI/6W3F30XLwIAlpeX4w+nTyORSmEkm8WBjz/OL5odCmFBJILf9vQgZ9voSSRwdngYttZDLu2HGDz9uEFa67hSap8GfnLk3LlAyOdDdNYsAMCau+7C30dG8NPDhxE0TTx+zz3ovnAhv3b3Aw9gf0cHthw6hAUzZ0JrPQbgrEu7IgY/USygkM93cFs0un5jZeV1/wU8eOqU3dzTc2g0l9vkxGxTCU8/CiiVy9X/Lh7P9CeT17WuP5lEczyeSVlWvUOjTSmMuoC01h1Zy9q1u60tda1hT1z7kbWsXVrrTodHnBJ4+uGAiav0tkaj/tX/6iq93l67+eRJXqVXYIzaIUqpJUHT3GPZ9mPfveMOHS0uDgRME+nJ11O3fnE9NY/QBcSoHaaUKjGUesprGM94lEoD6P7imy9v8psvzmDUN4lS6nUAnVrr192eRTq+UCRxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsQx3R7gW2QmgLsB+J3Y+JYtW+bcfvvt8wEsd2L7AEYAnAYw6tD2bxlKa+32DN8GPwDwGoCMU0+QSqUCHo9nbNq0aVmHnkJh/C/vagDHHHqOWwKjBr4P4E0AAbcHKZAkgAcBnHB7ELfwnBr4MeQEDYyfPq13ewg3MWqg1O0BCswEMM/tIdzEqMfPRSfp6+tDIBDAokWLAAAVFRXfeOMvvfQSUqnUN17f1dWF1tbW/M9NTU144YUXAACNjY248847sWPHjq8vu2yfphJGfRV33303urq6bng7hY76q3bu3Im6urpvvG2pGPU1KCkpAQBorfH8888jFoth4cKFaGlpAQAcOXIEa9euzT9+x44daGpqwssvv4z+/n7U1NSgpqYGABAOh7Fz505UVVXhkUcewcDAAABg5cqV6OzsBAAkEglUVFQgm81i7969aGlpwaJFi9DS0oJAIIBwOHwzd/+Ww/epr0FHRwcA4ODBg+jq6kJ3dzcSiQSWLl2Khx566Krrnn32Wezfvx9tbW0oLi4GAIyOjmLJkiVobGxEXV0dXnzxRbzyyitXXO/z+VBXV4fOzs6rPoYuxyP1dTh69CieeOIJeDwezJ49GytWrMgHf60Mw8CWLVsAALW1tTh69KgTo05pjLoATNOEbdv5nzOZa/8MRyl12TauZz1djlFfh+XLl6OlpQVjY2MYGBjAu+++i/vvvx9z585FPB7HpUuXMDw8jLfffju/Zvr06RgZGcn/bNs23nrrLQBAc3Mzli1bBmD8HZYPP/wQAPK/v9J6+vcY9XXYuHEjqqurcd999+Hhhx9GQ0MD5syZg/LycmzevBmxWAybN2/G4sWL82ueeeYZrFmzJv9CMRQKob29HbFYDO+88w727t0LAHjuuefw6quvYvHixUgkEvn1NTU1iMfj+ReK9O/xY3LgEwCVX72jr68Pa9euxUcffVTwJwuHw0gmkwXbXlNT05VeSDYBeLpgT3KL4ZEaSH/9Do/Hg88//zz/4cu3VWNjI+rr61FUVPT1X03p8xUeqcePalsBeF2eo1BSAP4LwBtuD+IWRg3MAvA+gArc+mGnALwD4HEAOZdncQ2jHjcLQD2A++DQFXuffvppWTAYTBcXFw86sX0AnwN4F8ALmMJBA4z6plFKvQ6gU2v9utuzSMcXiiQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw6hJHEZN4jBqEodRkziMmsRh1CQOoyZxGDWJw/+b3GFKqe8B+BGAxQCGAPQC+F+tddzVwQTjkdp50wH8J4AKjIe9AcCYi/OIx6iddwBA/xe3bQD/p7X+xMV5xGPUDtNajwH4bwAWxo/Q/+PuRPLxnPomUEp5AAwDOK21/g+XxxHPdHuAqUBrPaaUWgfgU7dnmQp4pHaYUuo2Q6mn/B5PtccwZozZ9nBmbOy4rXWT1nrA7fkkYtQOUUotDXq9eyzbfnRZWZn+TnFxIGiaSFkW4olE+r3z55VpGH9KWVa91rrD7XklYdQO8BrGdp9p7tsWjfpXVVQY032+yx4zks3icF+f3RyPZ7KWtStn26+5MKpIjLrAvIaxvWjatH0NNTXB0nB40u/+OTqKp1tb8cdNm+Axxt946k8msbutLXXx0qVdltZzAMzXWte6MLoYfEuvgJRSS32mecWgr6Y0HEZDTU3QZ5r7AJQ6O+HUwKgLKOj17tkWjfqvNegJpeEwtkajflOpZQ6NNqXwLb0CUEr9DMB2AHNbz5zB7FAID5aVYUxr/Pr4cfy1rw9BrxcbKysnrfvH6Cj2t7fjzPAw5kcihq11JYAeN/ZBEh6pC+OMAn6zsrw8XRuL4ecffIDBdBp/PnsW7Z99hl+uXo1frFqF986fn7So4dgxzI9E8Pt161BbVTXxIc08d3ZBDkZdAFrrAwHTrKgqKQmsKC9HWTiMTwYH8bdz57B+wQKUBIOY7vNh87335tdcSKVwamgIT8Zi8Ho8WFhSgnkzZsBQKuLirojA048CUEo9qYB1b3R3o+nECaQtCxezWQxmMigJBvOPuy0Uyt8eTKcR9nrhN7/8J4j4/VCA96YOLxCP1DdIKTUXwK+8hvH+D6urcWDDBlQUFUFrjZl+PwZSqfxjL3zldsTvRzKXQ8ay8vcNZTLQQO5mzi8Ro75xIQA6Z9vHTyYS6b/09qLv4kUAwPLycvzh9GkkUimMZLM48PHH+UWzQyEsiETw254e5GwbPYkEzg4Pw9Z6yKX9EIOnHzdIax1XSu3TwE+OnDsXCPl8iM6aBQBYc9dd+PvICH56+DCCponH77kH3Rcu5NfufuAB7O/owJZDh7Bg5syJy1TPurQrYvATxQIK+XwHt0Wj6zdWVl73X8CDp07ZzT09h0ZzuU1OzDaV8PSjgFK5XP3v4vFMfzJ5Xev6k0k0x+OZlGXVOzTalMKoC0hr3ZG1rF2729pS1xr2xLUfWcvapbXudHjEKYGnHw6YuEpvazTqX/2vrtLr7bWbT57kVXoFxqgdopRaEjTNPZZtP/bdO+7Q0eLiQMA0kZ58PXXrF9dT8whdQIzaYUqpkolvvhiGMcP+8psvb/KbL85g1CQOXyiSOIyaxGHUJA6jJnEYNYnDqEkcRk3iMGoSh1GTOIyaxPl/+jBzzvBfjuoAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALUAAACxCAYAAACCwvy/AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAMfUlEQVR4nO3df2wU95nH8c93dnbZX/hYYucHxsJEYOia2roIY6UJaVFALT0dP6OiBC64bXJntTkpEZKvnHTJn0Qgk6v6TxUqQZXiNLJEnDaiVahEJYIAAxIQeUmgxlagTmsc28L27Hp3PM/94XhTJ8HF9S7DPf68JIsFzwzP2G/GszuzwogIiDSx/B6AqNAYNanDqEkdRk3qMGpSh1GTOoya1GHUpA6jJnUYNanDqEkd2+8BtDPG3G8ZszMcCNQELGvemOcNZsbGLnkih0Tkpt/zaWR4Q1NxGGPqosHgbtfz1j9eXi5fKy2NRG0bjusi1deXPnnjhrEt63eO6+4RkbN+z6sJoy6CoGU1hmy7eXsyGV5bWWnNDYW+tMxQNotj3d1eSyqVybrurpzn/dyHUVVi1AUWtKzGkjlzmveuWRNdEI9P+txfR0bw/aNH8dutWxGwxp/O9AwPo+n4cefW6OguV+RBAEtEZIcPo6vBJ4oFZIypC9n2VwZ9OwvicexdsyYasu1mAAuKO+HswKgLKBoM7t6eTIbvNOgJC+JxPJNMhm1jHi/SaLMKX/0oAGPMTwA0Alh0tLMTD8Ri+EZ5OcZEcPDSJfyhuxvRYBCbq6omrfeXkRHsb29H5+AgliQSlidSBaDDj33QhEfqwug0wBvfqqhI71ixAvvOnEF/Oo3fX7uG9k8+wc/WrcNP167FyRs3Jq209/RpLEkk8OsNG7CjuhrGmACAh/3ZBT0YdQGISGvEtiury8oi36yoQHk8jo/6+3Hi+nVsXLoUZdEo5oZC+N7y5fl1eh0HVwYG8OyKFQgGAvh6WRkenjcPljEJH3dFBZ5+FIAx5lkDbPjFxYs49MEHSLsubmWz6M9kUBaN5pe7PxbLP+5PpxEPBhG2P/8WJMJhGCB4V4dXiEfqGTLGLAJwIGhZp35QU4PWTZtQWVICEcH8cBg3HSe/bO/fPE6EwxjO5ZBx3fyfDWQyECB3N+fXiFHPXAyA5Dzv0uW+vvR7XV3ovnULALC6ogK/uXoVfY6DoWwWrR9+mF/pgVgMSxMJ/KqjAznPQ0dfH64NDsITGfBpP9Tg6ccMiUjKGNMswI/+eP16JBYKIXnffQCA7yxejD8PDeHHx44hatvYsmwZLvb25tdtqq/H/rNnsa2tDUvnz4eIjAG45tOuqMErigUUC4WObE8mN26uqpr2T8AjV654LR0dbSO53NZizDab8PSjgJxcbs/hVCrTMzw8rfV6hofRkkplHNfdU6TRZhVGXUAicjbruruajh937jTsiXs/sq67S0TOFXnEWYGnH0UwcZfeM8lkeN1Ud+l1dXktly/zLr0CY9RFYoxZGbXt3a7nffexhQslWVoaidg20pPvpz762f3UPEIXEKMuMmNMmWXMzqBl/XvAmDSAi5+98+WXfOdLcTDqu8QY8zqAcyLyut+zaMcniqQOoyZ1GDWpw6hJHUZN6jBqUodRkzqMmtRh1KQOoyZ1GDWpw6hJHUZN6jBqUodRkzqMmtRh1KQOoyZ1GDWpw6hJHUZN6jBqUodRkzqMmtRh1KQOoyZ1GDWpw6hJHUZN6jBqUodRkzqMmtRh1KQOoyZ1GDWpw6hJHUZN6jBqUodRkzqMmtRh1KQOoyZ1GDWpw6hJHUZN6jBqUodRkzq23wP8P/EQgErM4Ou1bdu2Bx966KElAFbPYI4MgD8BGJjBNtQzIuL3DPcyA+B/AfwHxoP6hzmOEwkEAmNz5szJznCmMIDnAbwxw+2oxaintgfAfwKI+T3IFzgA/g3AEb8HuRcx6qndBFDq9xC38R6Ab/s9xL2ITxSnlvB7gCks9HuAexWjLqJDhw6hp6fnH16/u7sbLS0tBZxodmDURcSofSIi/Lj9hytf0NzcLNXV1VJdXS2vvfaadHV1SXV1df7z+/btk1deeUVaW1slFotJVVWV1NbWiuM4smjRImlqapK6ujqpq6uTq1eviojIzp07pbW1Nb+NWCwmIiL19fVSUlIitbW1sn///i+O0nEPfH3uyQ8eqafh/PnzOHjwIM6cOYPTp0/jwIEDGBj46peMn3rqKaxcuRKHDx/GhQsXEIlEAAAlJSVob2/HCy+8gBdffHHKv+/VV1/F6tWrceHCBbz00kuF3h21GPU0vP/++9i8eTNisRji8Ti2bNmCEydOTGsbTz/9dP7XU6dOFWPMWY9RT4PIl1/+HBwchOd5+d9nMlNfozHGfOmxbdv5bYgIstmZXp+Z3Rj1NDzxxBNoa2uD4zgYGRnB22+/jfXr16O3txeffvopRkdH8e677+aXnzt3LoaGhiZt46233sr/+uijjwIAKisrcf78eQDAO++8g1wud9v16e/jvR/T8Mgjj6ChoQGrVq0CADz33HOoq6vDyy+/jPr6eixevBjLly/PL9/Q0IDGxkZEIpH8qcbo6Cjq6+vheR7efPNNAMDzzz+PjRs3YtWqVXjyyScRi41fwKypqYFt26itrUVDQwPPq+8QryhOzQUQKNTGKisrce7cOZSWFuQiZQpAdSE2pA1PP6aW83uAKaT9HuBexdOPqXUCSGL8br0Z6+7uLsRmACAL4EKhNqYNTz+mlgRwEsA/oUBhF0AO4//YHgPQ7/Ms9yRG/fctB/AKgGWYwU+2jz/+uDwajaZLS0tnEmIa40fo3WDQt8Wo7xJjzOsAzonI637Poh2fKJI6jJrUYdSkDqMmdRg1qcOoSR1GTeowalKHUZM6jJrUYdSkDqMmdRg1qcOoSR1GTeowalKHUZM6jJrUYdSkDqMmdRg1qcOoSR1GTeowalKHUZM6jJrUYdSkDqMmdRg1qcOoSR1GTeowalKHUZM6jJrUYdSkDqMmdRg1qcOoSR1GTeowalKHUZM6jJrUYdSkDv9v8iIzxvwLgB8C+GcAAwC6APyPiKR8HUwxHqmLby6AfwVQifGwNwEY83Ee9Rh18bUC6PnssQfgHRH5yMd51GPURSYiYwD+C4CL8SP0f/s7kX48p74LjDEBAIMArorIIz6Po57t9wCzgYiMGWM2APjY71lmAx6pi8wYc79lzM5wIFATsKx5Y543mBkbu+SJHBKRm37PpxGjLhJjTF00GNztet76x8vL5WulpZGobcNxXaT6+tInb9wwtmX9znHdPSJy1u95NWHURRC0rMaQbTdvTybDaysrrbmh0JeWGcpmcay722tJpTJZ192V87yf+zCqSoy6wIKW1VgyZ07z3jVrogvi8Umf++vICL5/9Ch+u3UrAtb4C089w8NoOn7cuTU6ussVeRDAEhHZ4cPoavAlvQIyxtSFbPsrg76dBfE49q5ZEw3ZdjOABcWdcHZg1AUUDQZ3b08mw3ca9IQF8TieSSbDtjGPF2m0WYUv6RWAMeYnABoBLDra2YkHYjF8o7wcYyI4eOkS/tDdjWgwiM1VVZPW+8vICPa3t6NzcBBLEgnLE6kC0OHHPmjCI3VhdBrgjW9VVKR3rFiBfWfOoD+dxu+vXUP7J5/gZ+vW4adr1+LkjRuTVtp7+jSWJBL49YYN2FFdPXGR5mF/dkEPRl0AItIase3K6rKyyDcrKlAej+Oj/n6cuH4dG5cuRVk0irmhEL63fHl+nV7HwZWBATy7YgWCgQC+XlaGh+fNg2VMwsddUYGnHwVgjHnWABt+cfEiDn3wAdKui1vZLPozGZRFo/nl7o/F8o/702nEg0GE7c+/BYlwGAYI3tXhFeKReoaMMYsAHAha1qkf1NSgddMmVJaUQEQwPxzGTcfJL9v7N48T4TCGczlkXDf/ZwOZDATI3c35NWLUMxcDIDnPu3S5ry/9XlcXum/dAgCsrqjAb65eRZ/jYCibReuHH+ZXeiAWw9JEAr/q6EDO89DR14drg4PwRAZ82g81ePoxQyKSMsY0C/CjP16/HomFQkjedx8A4DuLF+PPQ0P48bFjiNo2tixbhou9vfl1m+rrsf/sWWxra8PS+fMnblO95tOuqMErigUUC4WObE8mN26uqpr2T8AjV654LR0dbSO53NZizDab8PSjgJxcbs/hVCrTMzw8rfV6hofRkkplHNfdU6TRZhVGXUAicjbruruajh937jTsiXs/sq67S0TOFXnEWYGnH0UwcZfeM8lkeN1Ud+l1dXktly/zLr0CY9RFYoxZGbXt3a7nffexhQslWVoaidg20pPvpz762f3UPEIXEKMuMmNM2cQ7XyzLmud9/s6XX/KdL8XBqEkdPlEkdRg1qcOoSR1GTeowalKHUZM6jJrUYdSkDqMmdRg1qfN/e+FEv4oZGfQAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 216x216 with 1 Axes>"
       ]
@@ -169,6 +169,45 @@
    ],
    "source": [
     "flow.draw_graph(figsize=(3, 3)).show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6657bbd9-3482-4123-a914-1bb5900a19a1",
+   "metadata": {},
+   "source": [
+    "Flows can also be visualised using [mermaid](https://mermaid.js.org). To generate the mermaid plotting syntax use the `to_mermaid` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8110d5a5-45bd-4daa-87bb-996a81e122aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "flowchart TD\n",
+      "    c923a1eb-af97-4a3e-9b19-c2ba36784177(add) -->|output| 950de35f-2762-4dd1-bb76-57cbe09f82a3(add)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from jobflow.utils.graph import to_mermaid\n",
+    "\n",
+    "print(to_mermaid(flow))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12920251-878e-4562-b458-9f30acfe7711",
+   "metadata": {},
+   "source": [
+    "The graph can be visualised by pasting the output into [GitHub](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/) or at [mermaid.live](https://mermaid.live).\n",
+    "\n",
+    "[![add flow](https://mermaid.ink/img/pako:eNpVTbluwzAU-xXjTS1gBbqvIVP-oJ0KL4qOJoBtGa6ENnX871WylRNJ8NjA5xDBQhrzt7-4tXTvp2HuGihmhGrmEWcpIu5lQGemAqJCSq8N91joFxfCa4fQ8Z5rWWq5d1j5sw-CIEZSaNUokSNBIaOMFlFw4ZJ8tqCHKa6Tu4b2vj0uByiXOMUBbKMhJlfHMsAw7y3qaslvt9mDLWuNPdQluBJPV_e5uglscuNXcxc3f-T8T4Pd4AcsJfTAmVSCY0KJVoL2cGs21QfOKVdcUUmwNHTv4fc5gQ_CKEEYlcw8EprtfzPzVns?type=png)](https://mermaid.live/edit#pako:eNpVTbluwzAU-xXjTS1gBbqvIVP-oJ0KL4qOJoBtGa6ENnX871WylRNJ8NjA5xDBQhrzt7-4tXTvp2HuGihmhGrmEWcpIu5lQGemAqJCSq8N91joFxfCa4fQ8Z5rWWq5d1j5sw-CIEZSaNUokSNBIaOMFlFw4ZJ8tqCHKa6Tu4b2vj0uByiXOMUBbKMhJlfHMsAw7y3qaslvt9mDLWuNPdQluBJPV_e5uglscuNXcxc3f-T8T4Pd4AcsJfTAmVSCY0KJVoL2cGs21QfOKVdcUUmwNHTv4fc5gQ_CKEEYlcw8EprtfzPzVns)"
    ]
   },
   {
@@ -194,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "black-berkeley",
    "metadata": {},
    "outputs": [
@@ -202,12 +241,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2021-06-04 17:56:25,875 INFO Started executing jobs locally\n",
-      "2021-06-04 17:56:25,877 INFO Starting job - add (3bc98d5e-b593-4ad1-a409-cef9136bb835)\n",
-      "2021-06-04 17:56:25,878 INFO Finished job - add (3bc98d5e-b593-4ad1-a409-cef9136bb835)\n",
-      "2021-06-04 17:56:25,879 INFO Starting job - add (846add3f-1d37-47a1-a7f5-94a0fdf57b1b)\n",
-      "2021-06-04 17:56:25,880 INFO Finished job - add (846add3f-1d37-47a1-a7f5-94a0fdf57b1b)\n",
-      "2021-06-04 17:56:25,881 INFO Finished executing jobs locally\n"
+      "2023-05-06 17:57:51,031 INFO Started executing jobs locally\n",
+      "2023-05-06 17:57:51,033 INFO Starting job - add (c923a1eb-af97-4a3e-9b19-c2ba36784177)\n",
+      "2023-05-06 17:57:51,034 INFO Finished job - add (c923a1eb-af97-4a3e-9b19-c2ba36784177)\n",
+      "2023-05-06 17:57:51,035 INFO Starting job - add (950de35f-2762-4dd1-bb76-57cbe09f82a3)\n",
+      "2023-05-06 17:57:51,036 INFO Finished job - add (950de35f-2762-4dd1-bb76-57cbe09f82a3)\n",
+      "2023-05-06 17:57:51,037 INFO Finished executing jobs locally\n"
      ]
     }
    ],
@@ -255,18 +294,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "hawaiian-entrance",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'3bc98d5e-b593-4ad1-a409-cef9136bb835': {1: Response(output=6, detour=None, addition=None, replace=None, stored_data=None, stop_children=False, stop_jobflow=False)},\n",
-       " '846add3f-1d37-47a1-a7f5-94a0fdf57b1b': {1: Response(output=9, detour=None, addition=None, replace=None, stored_data=None, stop_children=False, stop_jobflow=False)}}"
+       "{'c923a1eb-af97-4a3e-9b19-c2ba36784177': {1: Response(output=6, detour=None, addition=None, replace=None, stored_data=None, stop_children=False, stop_jobflow=False)},\n",
+       " '950de35f-2762-4dd1-bb76-57cbe09f82a3': {1: Response(output=9, detour=None, addition=None, replace=None, stored_data=None, stop_children=False, stop_jobflow=False)}}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -285,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "connected-africa",
    "metadata": {},
    "outputs": [
@@ -295,7 +334,7 @@
        "6"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -317,9 +356,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jobflow",
+   "display_name": "atomate2",
    "language": "python",
-   "name": "jobflow"
+   "name": "atomate2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -331,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/src/jobflow/utils/graph.py
+++ b/src/jobflow/utils/graph.py
@@ -181,7 +181,7 @@ def to_pydot(flow: jobflow.Flow):
     return pydot_graph
 
 
-def to_mermaid(flow: jobflow.Flow, show_flow_boxes: bool = True) -> str:
+def to_mermaid(flow: jobflow.Flow, show_flow_boxes: bool = False) -> str:
     """
     Convert a flow to a mermaid graph.
 
@@ -221,7 +221,6 @@ def to_mermaid(flow: jobflow.Flow, show_flow_boxes: bool = True) -> str:
     nodes = flow.graph.nodes(data=True)
 
     # add edges
-    seen_nodes = set()
     for u, v, d in flow.graph.edges(data=True):
         if isinstance(d["properties"], list):
             props = ", ".join(d["properties"])
@@ -229,7 +228,6 @@ def to_mermaid(flow: jobflow.Flow, show_flow_boxes: bool = True) -> str:
             props = d["properties"]
         line = f"    {u}({nodes[u]['label']}) -->|{props}| {v}({nodes[v]['label']})"
         lines.append(line)
-        seen_nodes.update({u, v})
 
     # add subgraphs
     def add_subgraph(nested_flow, prefix="    "):

--- a/src/jobflow/utils/graph.py
+++ b/src/jobflow/utils/graph.py
@@ -215,7 +215,7 @@ def to_mermaid(flow: jobflow.Flow, show_flow_boxes: bool = False) -> str:
 
     To render the graph, go to mermaid.live and paste the contents of ``graph_source``.
     """
-    from jobflow.core.flow import Flow
+    from jobflow import Flow
 
     lines = ["flowchart TD"]
     nodes = flow.graph.nodes(data=True)
@@ -230,18 +230,21 @@ def to_mermaid(flow: jobflow.Flow, show_flow_boxes: bool = False) -> str:
         lines.append(line)
 
     # add subgraphs
-    def add_subgraph(nested_flow, prefix="    "):
+    def add_subgraph(nested_flow, indent_level=1):
+        prefix = "    " * indent_level
+
         for job in nested_flow.jobs:
             if isinstance(job, Flow):
                 if show_flow_boxes:
                     lines.append(f"{prefix}subgraph {job.uuid} [{job.name}]")
 
-                add_subgraph(job, prefix=prefix + "    ")
+                add_subgraph(job, indent_level=indent_level + 1)
 
                 if show_flow_boxes:
                     lines.append(f"{prefix}end")
             else:
-                lines.append(f"{prefix}{job.uuid}({job.name})")
+                if indent_level != 1:
+                    lines.append(f"{prefix}{job.uuid}({job.name})")
 
     add_subgraph(flow)
 

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -121,7 +121,7 @@ def test_to_mermaid():
     flow2 = Flow([add_job3, add_job4])
     main_flow = Flow([flow1, flow2])
 
-    mermaid = to_mermaid(main_flow)
+    mermaid = to_mermaid(main_flow, show_flow_boxes=True)
     assert "subgraph" in mermaid
 
     # test without flow boxes

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -98,3 +98,32 @@ def test_to_pydot():
 
     pydot = to_pydot(main_flow)
     assert pydot is not None
+
+
+def test_to_mermaid():
+    from jobflow import Flow, Job
+    from jobflow.utils.graph import to_mermaid
+
+    # test edges
+    add_job1 = Job(add, function_args=(1, 2))
+    add_job2 = Job(add, function_args=(1, add_job1.output))
+    flow = Flow([add_job1, add_job2])
+
+    mermaid = to_mermaid(flow)
+    assert mermaid is not None
+
+    # test nested
+    add_job1 = Job(add, function_args=(1, 2))
+    add_job2 = Job(add, function_args=(1, 2))
+    add_job3 = Job(add, function_args=(1, 2))
+    add_job4 = Job(add, function_args=(1, 2))
+    flow1 = Flow([add_job1, add_job2])
+    flow2 = Flow([add_job3, add_job4])
+    main_flow = Flow([flow1, flow2])
+
+    mermaid = to_mermaid(main_flow)
+    assert "subgraph" in mermaid
+
+    # test without flow boxes
+    mermaid = to_mermaid(main_flow, show_flow_boxes=False)
+    assert "subgraph" not in mermaid

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -118,7 +118,7 @@ def test_to_mermaid():
     flow = Flow([add_job1, add_job2])
 
     mermaid = to_mermaid(flow)
-    assert "prop1, prop2" in mermaid
+    assert ("prop1, prop2" in mermaid) or ("prop2, prop1" in mermaid)
 
     # test nested
     add_job1 = Job(add, function_args=(1, 2))

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -112,6 +112,14 @@ def test_to_mermaid():
     mermaid = to_mermaid(flow)
     assert mermaid is not None
 
+    # test list of properties
+    add_job1 = Job(add, function_args=(1, 2))
+    add_job2 = Job(add, function_args=(add_job1.output.prop1, add_job1.output.prop2))
+    flow = Flow([add_job1, add_job2])
+
+    mermaid = to_mermaid(flow)
+    assert "prop1, prop2" in mermaid
+
     # test nested
     add_job1 = Job(add, function_args=(1, 2))
     add_job2 = Job(add, function_args=(1, 2))


### PR DESCRIPTION
## Summary

Addresses #301 

Based on @mkhorton's suggestion and code snippet, I've added a function to enable visualising Flow's in mermaid.

I made a few adjustments to allow for:
- Nested flows and flow boxes
- Supporting flows with no connections between jobs.

## Examples

These may be of interest to @JaGeo. Note, the flow boxes are disabled by default but I've included them in these plots.

### Phonon Workflow

![phonon](https://user-images.githubusercontent.com/1330638/236639726-e8edd550-f716-49a2-9cd3-da33c081d611.svg)

### Elastic workflow

![elastic](https://user-images.githubusercontent.com/1330638/236641493-dabcf764-0eec-419f-ada3-a7e2e71f3154.svg)


### Lobster workflow

![lobster](https://user-images.githubusercontent.com/1330638/236641503-5ce64668-5d12-444a-87dc-79dc5ecbd584.svg)

### Electron-phonon workflow

![elph](https://user-images.githubusercontent.com/1330638/236641522-57f6c6cd-35e4-45cb-8b5d-5db299de1107.svg)
