### PR TITLE
[WIP] Update `fw_spec` in Fireworks manager

### DIFF
--- a/src/jobflow/managers/fireworks.py
+++ b/src/jobflow/managers/fireworks.py
@@ -153,6 +153,8 @@ class JobFiretask(FiretaskBase):
             store = SETTINGS.JOB_STORE
         store.connect()
 
+        job.metadata.update({"fw_spec":fw_spec})
+
         if hasattr(self, "fw_id"):
             job.metadata.update({"fw_id": self.fw_id})
 


### PR DESCRIPTION
The passed `fw_spec` was never being added to the job metadata. That is now taken care of.

I am merely a proxy for @samblau who was too lazy to open the PR himself. 😉