### PR TITLE
Fixed JobStore.from_dict_spec so that the original dict_spec is not modified

### DIFF
--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -679,7 +679,8 @@ def _construct_store(spec_dict, valid_stores):
     (e.g. stored in a database), or if there is some validation by a pydantic
     schema.
     This does not occur when using jobflow's standard loading of a config file
-    as it is only called once."""
+    as it is only called once.
+    """
     _spec_dict = dict(spec_dict)
     store_type = _spec_dict.pop("type")
     for k, v in _spec_dict.items():

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -672,12 +672,20 @@ class JobStore(Store):
 
 
 def _construct_store(spec_dict, valid_stores):
-    """Parse the dict containing {"type": <StoreType>} recursively."""
-    store_type = spec_dict.pop("type")
-    for k, v in spec_dict.items():
+    """Parse the dict containing {"type": <StoreType>} recursively.
+
+    Note: the spec is copied so that if this is used programmatically, the type
+    is not removed from the original spec_dict, which may be used afterwards,
+    (e.g. stored in a database), or if there is some validation by a pydantic
+    schema.
+    This does not occur when using jobflow's standard loading of a config file
+    as it is only called once."""
+    _spec_dict = dict(spec_dict)
+    store_type = _spec_dict.pop("type")
+    for k, v in _spec_dict.items():
         if isinstance(v, dict) and "type" in v:
-            spec_dict[k] = _construct_store(v, valid_stores)
-    return valid_stores[store_type](**spec_dict)
+            _spec_dict[k] = _construct_store(v, valid_stores)
+    return valid_stores[store_type](**_spec_dict)
 
 
 def _prepare_load(

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -434,6 +434,44 @@ def test_from_db_file(test_data):
         JobStore.from_file(test_data / "db_bad.yaml")
 
 
+def test_from_dict_spec():
+    from jobflow import JobStore
+    dict_spec = {
+        'docs_store': {
+            'type': 'MongoStore',
+            'database': 'jobflow_unittest',
+            'collection_name': 'outputs',
+            'host': 'localhost',
+            'port': 27017
+        }
+    }
+    JobStore.from_dict_spec(dict_spec)
+    assert 'type' in dict_spec['docs_store']
+    dict_spec = {
+        'docs_store': {
+            'type': 'MongoStore',
+            'database': 'jobflow_unittest',
+            'collection_name': 'outputs',
+            'host': 'localhost',
+            'port': 27017,
+        },
+        'additional_stores': {
+            'data': {
+                'type': 'GridFSStore',
+                'database': 'jobflow_unittest',
+                'collection_name': 'outputs_blobs',
+                'host': 'localhost',
+                'port': 27017,
+            }
+        }
+    }
+    JobStore.from_dict_spec(dict_spec)
+    assert 'type' in dict_spec['docs_store']
+    assert dict_spec['docs_store']['type'] == 'MongoStore'
+    assert 'type' in dict_spec['additional_stores']['data']
+    assert dict_spec['additional_stores']['data']['type'] == 'GridFSStore'
+
+
 def test_ensure_index(memory_jobstore):
     assert memory_jobstore.ensure_index("test_key")
     # TODO: How to check for exception?

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -436,40 +436,41 @@ def test_from_db_file(test_data):
 
 def test_from_dict_spec():
     from jobflow import JobStore
+
     dict_spec = {
-        'docs_store': {
-            'type': 'MongoStore',
-            'database': 'jobflow_unittest',
-            'collection_name': 'outputs',
-            'host': 'localhost',
-            'port': 27017
+        "docs_store": {
+            "type": "MongoStore",
+            "database": "jobflow_unittest",
+            "collection_name": "outputs",
+            "host": "localhost",
+            "port": 27017,
         }
     }
     JobStore.from_dict_spec(dict_spec)
-    assert 'type' in dict_spec['docs_store']
+    assert "type" in dict_spec["docs_store"]
     dict_spec = {
-        'docs_store': {
-            'type': 'MongoStore',
-            'database': 'jobflow_unittest',
-            'collection_name': 'outputs',
-            'host': 'localhost',
-            'port': 27017,
+        "docs_store": {
+            "type": "MongoStore",
+            "database": "jobflow_unittest",
+            "collection_name": "outputs",
+            "host": "localhost",
+            "port": 27017,
         },
-        'additional_stores': {
-            'data': {
-                'type': 'GridFSStore',
-                'database': 'jobflow_unittest',
-                'collection_name': 'outputs_blobs',
-                'host': 'localhost',
-                'port': 27017,
+        "additional_stores": {
+            "data": {
+                "type": "GridFSStore",
+                "database": "jobflow_unittest",
+                "collection_name": "outputs_blobs",
+                "host": "localhost",
+                "port": 27017,
             }
-        }
+        },
     }
     JobStore.from_dict_spec(dict_spec)
-    assert 'type' in dict_spec['docs_store']
-    assert dict_spec['docs_store']['type'] == 'MongoStore'
-    assert 'type' in dict_spec['additional_stores']['data']
-    assert dict_spec['additional_stores']['data']['type'] == 'GridFSStore'
+    assert "type" in dict_spec["docs_store"]
+    assert dict_spec["docs_store"]["type"] == "MongoStore"
+    assert "type" in dict_spec["additional_stores"]["data"]
+    assert dict_spec["additional_stores"]["data"]["type"] == "GridFSStore"
 
 
 def test_ensure_index(memory_jobstore):


### PR DESCRIPTION
Fixed JobStore.from_dict_spec so that the original dict_spec is not modified.
The spec is now copied so that if this is used programmatically, the type is not removed from the original spec_dict, which may be used afterwards, (e.g. stored in a database), or if there is some validation by a pydantic schema.

@utf For information, this is making the jobflow-remote fail in some of the config cases.

## Summary

Include a summary of major changes in bullet points:

- Modification of the internal `_construct_store` method so that the original dict_spec is not modified.

## Additional dependencies introduced (if any)

None

## TODO (if any)

None

## Checklist


