### PR TITLE
Allow bson objects as job inputs, e.g. datetime.datetimes

### DIFF
--- a/src/jobflow/utils/find.py
+++ b/src/jobflow/utils/find.py
@@ -213,7 +213,7 @@ def contains_flow_or_job(obj: Any) -> bool:
         # argument is a primitive, we won't find an flow or job here
         return False
 
-    obj = jsanitize(obj, strict=True)
+    obj = jsanitize(obj, strict=True, allow_bson=True)
 
     # recursively find any reference classes
     locations = find_key_value(obj, "@class", "Flow")

--- a/tests/utils/test_find.py
+++ b/tests/utils/test_find.py
@@ -54,6 +54,8 @@ def test_update_in_dictionary():
 
 
 def test_contains_job_or_flow():
+    from datetime import datetime
+
     from jobflow import Flow, Job
     from jobflow.utils import contains_flow_or_job
 
@@ -74,3 +76,4 @@ def test_contains_job_or_flow():
     assert contains_flow_or_job([[job]]) is True
     assert contains_flow_or_job({"a": job}) is True
     assert contains_flow_or_job({"a": [job]}) is True
+    assert contains_flow_or_job({"a": [job], "b": datetime.now()}) is True


### PR DESCRIPTION
## Summary

Adds the `allow_bson=True` kwarg to the `jsanitize` invocation in `contains_job_or_flow` utility function, and a corresponding test case. I recently tried to pass an object containing a `datetime.datetime` in it as an input to a job (specifically, the object was an emmet `TaskDoc`. This object was the output of another job (and I had retrieved it from the jobstore).

I noticed that every other invocation of jsanitize in the codebase uses `allow_bson=True`, with the exception of the one in `Job::as_dict`, so I concluded that this might be a bug. Please feel free to close if this behavior is intentional! However, I think it's useful to allow things like `datetime`s as inputs (at least to allow the use of TaskDocs as input parameters).

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [X] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply
`cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
