### PR TITLE
Also allow_bson in job serialization

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -1068,7 +1068,7 @@ class Job(MSONable):
 
         # fireworks can't serialize functions and classes, so explicitly serialize to
         # the job recursively using monty to avoid issues
-        return jsanitize(d, strict=True, enum_values=True)
+        return jsanitize(d, strict=True, enum_values=True, allow_bson=True)
 
     def __setattr__(self, key, value):
         """Handle setting attributes. Implements a special case for job name."""

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -558,12 +558,15 @@ def test_response():
 
 def test_serialization():
     import json
+    from datetime import datetime
 
     from monty.json import MontyDecoder, MontyEncoder
 
     from jobflow import Job
 
-    test_job = Job(function=add, function_args=(1,), function_kwargs={"b": 2})
+    test_job = Job(
+        function=add, function_args=(1, datetime.now()), function_kwargs={"b": 2}
+    )
 
     uuid = test_job.uuid
 


### PR DESCRIPTION
## Summary

An extension of https://github.com/materialsproject/jobflow/pull/375. If we allow bson inputs to be serialized, then job serialization must also accommodate that (since job serialization involves serializing the function_args, i.e. inputs).

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply
`cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
