### PR TITLE
External references

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -750,7 +750,8 @@ class Flow(MSONable):
 
 
 def get_flow(
-    flow: Flow | jobflow.Job | list[jobflow.Job], allow_external_references: bool = True
+    flow: Flow | jobflow.Job | list[jobflow.Job],
+    allow_external_references: bool = False,
 ) -> Flow:
     """
     Check dependencies and return flow object.

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -252,6 +252,11 @@ class Flow(MSONable):
 
         graph = nx.compose_all([job.graph for job in self.jobs])
 
+        for node in graph:
+            node_props = graph.nodes[node]
+            if all(k not in node_props for k in ("job", "label")):
+                nx.set_node_attributes(graph, {node: {"label": "external"}})
+
         if self.order == JobOrder.LINEAR:
             # add fake edges between jobs to force linear order
             edges = []
@@ -329,7 +334,9 @@ class Flow(MSONable):
             )
 
         for node in itergraph(graph):
-            parents = [u for u, v in graph.in_edges(node)]
+            parents = [u for u, v in graph.in_edges(node) if "job" in graph.nodes[u]]
+            if "job" not in graph.nodes[node]:
+                continue
             job = graph.nodes[node]["job"]
             yield job, parents
 
@@ -743,7 +750,7 @@ class Flow(MSONable):
 
 
 def get_flow(
-    flow: Flow | jobflow.Job | list[jobflow.Job],
+    flow: Flow | jobflow.Job | list[jobflow.Job], allow_external_references: bool = True
 ) -> Flow:
     """
     Check dependencies and return flow object.
@@ -752,6 +759,9 @@ def get_flow(
     ----------
     flow
         A job, list of jobs, or flow.
+    allow_external_references
+        If False all the references to other outputs should be from other Jobs
+        of the Flow.
 
     Returns
     -------
@@ -761,14 +771,15 @@ def get_flow(
     if not isinstance(flow, Flow):
         flow = Flow(jobs=flow)
 
-    # ensure that we have all the jobs needed to resolve the reference connections
-    job_references = find_and_get_references(flow.jobs)
-    job_reference_uuids = {ref.uuid for ref in job_references}
-    missing_jobs = job_reference_uuids.difference(set(flow.job_uuids))
-    if len(missing_jobs) > 0:
-        raise ValueError(
-            "The following jobs were not found in the jobs array and are needed to "
-            f"resolve output references:\n{list(missing_jobs)}"
-        )
+    if not allow_external_references:
+        # ensure that we have all the jobs needed to resolve the reference connections
+        job_references = find_and_get_references(flow.jobs)
+        job_reference_uuids = {ref.uuid for ref in job_references}
+        missing_jobs = job_reference_uuids.difference(set(flow.job_uuids))
+        if len(missing_jobs) > 0:
+            raise ValueError(
+                "The following jobs were not found in the jobs array and are needed to "
+                f"resolve output references:\n{list(missing_jobs)}"
+            )
 
     return flow

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -882,7 +882,9 @@ def get_flow(
         if len(missing_jobs) > 0:
             raise ValueError(
                 "The following jobs were not found in the jobs array and are needed to "
-                f"resolve output references:\n{list(missing_jobs)}"
+                f"resolve output references:\n{list(missing_jobs)}\nIf the references "
+                "are from external jobs and this is the intended behavior set "
+                "allow_external_references to True"
             )
 
     return flow

--- a/src/jobflow/managers/fireworks.py
+++ b/src/jobflow/managers/fireworks.py
@@ -17,6 +17,7 @@ __all__ = ["flow_to_workflow", "job_to_firework", "JobFiretask"]
 def flow_to_workflow(
     flow: jobflow.Flow | jobflow.Job | list[jobflow.Job],
     store: jobflow.JobStore | None = None,
+    allow_external_references: bool = False,
     **kwargs,
 ) -> Workflow:
     """
@@ -35,6 +36,9 @@ def flow_to_workflow(
         will be used. Note, this could be different on the computer that submits the
         workflow and the computer which runs the workflow. The value of ``JOB_STORE`` on
         the computer that runs the workflow will be used.
+    allow_external_references
+        If False all the references to other outputs should be from other Jobs
+        of the Flow.
     **kwargs
         Keyword arguments passed to Workflow init method.
 
@@ -50,7 +54,7 @@ def flow_to_workflow(
     parent_mapping: dict[str, Firework] = {}
     fireworks = []
 
-    flow = get_flow(flow)
+    flow = get_flow(flow, allow_external_references=allow_external_references)
 
     for job, parents in flow.iterflow():
         fw = job_to_firework(job, store, parents=parents, parent_mapping=parent_mapping)

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -21,6 +21,7 @@ def run_locally(
     store: jobflow.JobStore | None = None,
     create_folders: bool = False,
     ensure_success: bool = False,
+    allow_external_references: bool = False,
 ) -> dict[str, dict[int, jobflow.Response]]:
     """
     Run a :obj:`Job` or :obj:`Flow` locally.
@@ -39,6 +40,9 @@ def run_locally(
         Whether to run each job in a new folder.
     ensure_success
         Raise an error if the flow was not executed successfully.
+    allow_external_references
+        If False all the references to other outputs should be from other Jobs
+        of the Flow.
 
     Returns
     -------
@@ -64,7 +68,7 @@ def run_locally(
     if log:
         initialize_logger()
 
-    flow = get_flow(flow)
+    flow = get_flow(flow, allow_external_references=allow_external_references)
 
     stopped_parents: set[str] = set()
     errored: set[str] = set()

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -340,6 +340,15 @@ def test_graph():
     assert len(graph.edges) == 5
     assert len(graph.nodes) == 4
 
+    # test external reference
+    add_job1 = get_test_job()
+    add_job2 = get_test_job()
+    add_job1.function_args = (2, add_job2.output)
+    flow = Flow([add_job1])
+    graph = flow.graph
+    assert len(graph.edges) == 1
+    assert len(graph.nodes) == 2
+
 
 def test_draw_graph():
     from jobflow import Flow, JobOrder
@@ -403,7 +412,7 @@ def test_draw_graph_nopydot():
 
 
 def test_iterflow():
-    from jobflow import Flow, JobOrder
+    from jobflow import Flow, JobOrder, OutputReference
 
     # test unconnected graph
     add_job1 = get_test_job()
@@ -446,6 +455,12 @@ def test_iterflow():
     flow = Flow([add_job1, add_job2], order=JobOrder.LINEAR)
     with pytest.raises(ValueError):
         list(flow.iterflow())
+
+    # test with external reference
+    add_job1 = get_test_job()
+    add_job1.function_args = (2, OutputReference("a-fake-uuid"))
+    flow = Flow([add_job1], order=JobOrder.LINEAR)
+    list(flow.iterflow())
 
 
 def test_dag_validation():

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -595,7 +595,11 @@ def test_get_flow():
     job1 = Job(add, function_args=(1, 2))
     job2 = Job(add, function_args=(job1.output.value, 2))
     with pytest.raises(ValueError):
-        get_flow(job2)
+        get_flow(job2, allow_external_references=False)
+
+    job1 = Job(add, function_args=(1, 2))
+    job2 = Job(add, function_args=(job1.output.value, 2))
+    assert get_flow(job2, allow_external_references=True)
 
     # test all jobs included for graph to work
     job1 = Job(add, function_args=(1, 2))

--- a/tests/managers/test_fireworks.py
+++ b/tests/managers/test_fireworks.py
@@ -571,3 +571,45 @@ def test_replace_and_detour_flow(
     assert result2["output"] == "11_end"
     assert result3["output"] == "xyz_end"
     assert result4["output"] == "12345_end"
+
+
+def test_external_reference(lpad, mongo_jobstore, fw_dir, simple_job, capsys):
+    from fireworks.core.rocket_launcher import rapidfire
+
+    from jobflow import Flow, OutputReference
+    from jobflow.managers.fireworks import flow_to_workflow
+
+    # run a first flow
+    job1 = simple_job("12345")
+    uuid1 = job1.uuid
+    flow1 = Flow([job1])
+    wf1 = flow_to_workflow(flow1, mongo_jobstore)
+    fw_ids = lpad.add_wf(wf1)
+
+    # run the workflow
+    rapidfire(lpad)
+
+    # check workflow completed
+    fw_id = list(fw_ids.values())[0]
+    wf1 = lpad.get_wf_by_fw_id(fw_id)
+    assert all([s == "COMPLETED" for s in wf1.fw_states.values()])
+
+    # run a second flow with external reference to the first
+    job2 = simple_job(OutputReference(uuid1))
+    uuid2 = job2.uuid
+    flow2 = Flow([job2])
+    wf2 = flow_to_workflow(flow2, mongo_jobstore, allow_external_references=True)
+    fw_ids = lpad.add_wf(wf2)
+
+    # run the workflow
+    rapidfire(lpad)
+
+    # check workflow completed
+    fw_id = list(fw_ids.values())[0]
+    wf2 = lpad.get_wf_by_fw_id(fw_id)
+    assert all([s == "COMPLETED" for s in wf2.fw_states.values()])
+
+    # check response
+    result2 = mongo_jobstore.query_one({"uuid": uuid2})
+    print(result2)
+    assert result2["output"] == "12345_end_end"

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -361,3 +361,21 @@ def test_detour_stop_flow(memory_jobstore, clean_dir, detour_stop_flow):
     assert result1["output"] == 11
     assert result2["output"] == "1234"
     assert result3 is None
+
+
+def test_external_reference(memory_jobstore, clean_dir, simple_job):
+    from jobflow import OutputReference, run_locally
+
+    # run a first job
+    job1 = simple_job("12345")
+    uuid1 = job1.uuid
+    responses = run_locally(job1, store=memory_jobstore)
+
+    # check responses has been filled
+    assert responses[uuid1][1].output == "12345_end"
+
+    # run a second job with external reference to the first
+    job2 = simple_job(OutputReference(uuid1))
+    uuid2 = job2.uuid
+    responses = run_locally(job2, store=memory_jobstore, allow_external_references=True)
+    assert responses[uuid2][1].output == "12345_end_end"


### PR DESCRIPTION
## Summary

Currently Jobflow prevents using an `OutputReference` as an input for a Job/Flow if the Job being referred does not belong to the same Flow.

However, I think there are cases where it could be useful to pass the reference to the output of a Job/Flow that has finished previously. 
Of course the use of the external reference could be avoided by fetching the output of the first Flow and pass it as an input of the new Flow. But what if the output is very large and does not fit in the MongoDB size limit? Allowing external references will allow to avoid this kind of issues, avoid repetition of the data in the DB and potentially allow to reconstruct connections between different flows.

I thought it would have been easier to test this option and directly open a PR rather than discussing it in an issue beforehand. Is this change acceptable?
An obvious downside would be that a user may mistakenly end up with connected Flows without the guarantee of the correct order of execution. Do you think this would be a blocking issue? Or any suggestion about how to better handle it?

Here an example of usage of the code with an external reference:

``` python
from jobflow import job, Flow, OutputReference
from jobflow.managers.local import run_locally

@job
def add(a, b):
    return a + b

add_first = add(1, 5)
add_second = add(add_first.output, 3)

flow1 = Flow([add_first, add_second])
responses1 = run_locally(flow1)

add_third = add(OutputReference(add_second.uuid), 5)

flow2 = Flow([add_third])
responses2 = run_locally(flow2)
```

## TODO 

Add specific tests if the change is acceptable.
