### PR TITLE
Fix `TypeError` when passing name to `flow_to_workflow()`

### DIFF
--- a/src/jobflow/managers/fireworks.py
+++ b/src/jobflow/managers/fireworks.py
@@ -56,7 +56,7 @@ def flow_to_workflow(
         fw = job_to_firework(job, store, parents=parents, parent_mapping=parent_mapping)
         fireworks.append(fw)
 
-    return Workflow(fireworks, name=flow.name, **kwargs)
+    return Workflow(fireworks, name=kwargs.pop("name", flow.name), **kwargs)
 
 
 def job_to_firework(

--- a/tests/managers/test_fireworks.py
+++ b/tests/managers/test_fireworks.py
@@ -18,12 +18,12 @@ def test_flow_to_workflow(
     assert len(wf.fws) == 1
     assert wf.fws[0].name == "func"
 
-    # test simple job no store
+    # test simple job no store with custom name
     flow = simple_job()
-    wf = flow_to_workflow(flow)
+    wf = flow_to_workflow(flow, name="custom_name")
 
     assert type(wf) == Workflow
-    assert wf.name == "Flow"
+    assert wf.name == "custom_name"
     assert len(wf.fws) == 1
     assert wf.fws[0].name == "func"
 


### PR DESCRIPTION
Closes #395.

62eb2c9 fix `TypeError` when passing name to `flow_to_workflow()`
bb3d972 test `flow_to_workflow()` with custom name