### PR TITLE
Link to @jageo's tutorials and fix a broken link

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -1,10 +1,6 @@
 Tutorials
 =========
 
-.. Note::
-    These tutorials are a work in progress. Additional tutorials on the more advanced
-    features of jobflow will be added soon.
-
 .. toctree::
    :maxdepth: 1
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -12,3 +12,6 @@ Tutorials
    tutorials/6-makers
    tutorials/7-generalized-makers
    tutorials/8-fireworks
+
+.. Note::
+    [@jageo](https://github.com/JaGeo) also has a set of [Jobflow tutorials](https://jageo.github.io/Advanced_Jobflow_Tutorial/intro.html) written within the context of computational materials science applications, which you may wish to check out after exploring the basics here.

--- a/docs/tutorials/2-introduction.ipynb
+++ b/docs/tutorials/2-introduction.ipynb
@@ -496,7 +496,7 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "Now that you are more familiar jobflows, we encourage you to learn about all the different options jobflow provides for designing and running workflows. A good next step is the [Defining Jobs using jobflow tutorial](https://hackingmaterials.lbl.gov/jobflow/tutorials/3-defining-jobs.html), which will cover the `Job` object and `job` decorator in more detail.\n"
+    "Now that you are more familiar jobflows, we encourage you to learn about all the different options jobflow provides for designing and running workflows. A good next step is the [Defining Jobs using jobflow tutorial](https://materialsproject.github.io/jobflow/tutorials/3-defining-jobs.html), which will cover the `Job` object and `job` decorator in more detail.\n"
    ]
   }
  ],


### PR DESCRIPTION
Closes #410.

This PR adds a hyperlink to @jageo's very nice Jobflow tutorials and fixes a broken hyperlink. I also removed a notice that more tutorials will be added "soon" so as not give a false impression. Besides, we covered most of the main content now.