### PR TITLE
Add tests for Python 3.11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
         run: pytest --cov=jobflow --cov-report=xml
 
       - uses: codecov/codecov-action@v1
-        if: matrix.python-version == '3.10' && github.repository == 'materialsproject/jobflow'
+        if: matrix.python-version == '3.11' && github.repository == 'materialsproject/jobflow'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,13 @@ license = { text = "modified BSD" }
 authors = [{ name = "Alex Ganose", email = "alexganose@gmail.com" }]
 dynamic = ["version"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -30,7 +31,7 @@ dependencies = [
     "maggma>=0.38.1",
     "monty>=2021.5.9",
     "networkx",
-    "pydantic",
+    "pydantic<2",
     "pydash",
 ]
 


### PR DESCRIPTION
- I added Python 3.11 to the test suite and updated the relevant parts of the repo to make it clear 3.11 is supported.
- I pinned pydantic to <2 for now.
- I updated the classifier for the project status to "Development Status :: 5 - Production/Stable"