### PR TITLE
Add warning when jobflow.yaml is blank or badly formatted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
     "sphinx==7.2.4",
 ]
 dev = ["pre-commit>=2.12.1"]
-tests = ["pytest-cov==4.1.0", "pytest==7.4.0"]
+tests = ["pytest-cov==4.1.0", "pytest==7.4.0","moto==4.2.0"]
 vis = ["matplotlib", "pydot"]
 fireworks = ["FireWorks"]
 strict = [

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,5 +1,6 @@
 """Settings for jobflow."""
 
+import warnings
 from collections import defaultdict
 from pathlib import Path
 
@@ -136,10 +137,17 @@ class JobflowSettings(BaseSettings):
         from monty.serialization import loadfn
 
         config_file_path: str = values.get("CONFIG_FILE", DEFAULT_CONFIG_FILE_PATH)
-
         new_values = {}
         if Path(config_file_path).exists():
-            new_values.update(loadfn(config_file_path))
+            try:
+                new_values.update(loadfn(config_file_path))
+            # Catching these two error types is required to handle
+            # empty and malformed configs
+            except (TypeError, ValueError):
+                warnings.warn(
+                    f"JobFlow config file was located at {config_file_path} "
+                    f"but there was a problem while parsing it."
+                )
 
         store = new_values.get("JOB_STORE")
         if isinstance(store, str):

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from maggma.stores import MemoryStore
-from pydantic import BaseSettings, Field, ValidationError, root_validator
+from pydantic import BaseSettings, Field, root_validator
 
 from jobflow import JobStore
 
@@ -146,7 +146,7 @@ class JobflowSettings(BaseSettings):
             else:
                 try:
                     new_values.update(loadfn(config_file_path))
-                except ValidationError:
+                except ValueError:
                     raise ValueError(
                         f"A JobFlow configuration file was located at "
                         f"{config_file_path} but a problem was "

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_settings_init():
     import os
 
@@ -69,7 +72,22 @@ def test_settings_object(clean_dir, test_data):
     }
 
     # set the path to lood settings from
-    os.environ["JOBFLOW_CONFIG_FILE"] = str(Path.cwd() / "config.yaml")
+    config_file_path = str(Path.cwd() / "config.yaml")
+    os.environ["JOBFLOW_CONFIG_FILE"] = config_file_path
+
+    # A warning should appear if config file is empty
+    with open(config_file_path, "w") as f:
+        pass
+
+    with pytest.warns(UserWarning):
+        settings = JobflowSettings()
+
+    # A warning should appear if the config file is not valid yaml
+    with open(config_file_path, "w") as f:
+        f.write("Some text that sadly is not yaml")
+
+    with pytest.warns(UserWarning):
+        settings = JobflowSettings()
 
     # assert loading monty spec from files works
     dumpfn({"JOB_STORE": monty_spec}, "config.yaml")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -87,7 +87,7 @@ def test_settings_object(clean_dir, test_data):
     with open(config_file_path, "w") as f:
         f.write("Some text that sadly is not yaml")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="A JobFlow configuration"):
         settings = JobflowSettings()
 
     # assert loading monty spec from files works

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -82,11 +82,12 @@ def test_settings_object(clean_dir, test_data):
     with pytest.warns(UserWarning):
         settings = JobflowSettings()
 
-    # A warning should appear if the config file is not valid yaml
+    # An error should be thrown if the file exists and
+    # contains badly formatted contents
     with open(config_file_path, "w") as f:
         f.write("Some text that sadly is not yaml")
 
-    with pytest.warns(UserWarning):
+    with pytest.raises(ValueError):
         settings = JobflowSettings()
 
     # assert loading monty spec from files works


### PR DESCRIPTION
## Summary

Addresses #411, and adds moto as a testing dependency.

## Additional dependencies introduced (if any)

- moto is added as a test dependency, but this is because it is already used in a test in tests/core/test_store.py

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply
`cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
