### PR TITLE
Reconstruct flow from outputs in JobStore [WIP]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ docs = [
     "furo==2023.8.19",
     "ipython==8.14.0",
     "myst_parser==2.0.0",
-    "nbsphinx==0.9.2",
+    "nbsphinx==0.9.3",
     "sphinx-copybutton==0.5.2",
     "sphinx==7.2.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ fireworks = ["FireWorks"]
 strict = [
     "FireWorks==2.0.3",
     "PyYAML==6.0.1",
-    "maggma==0.53.0",
+    "maggma==0.53.1",
     "matplotlib==3.7.2",
     "monty==2023.8.8",
     "moto==4.1.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ strict = [
     "maggma==0.53.1",
     "matplotlib==3.7.2",
     "monty==2023.8.8",
-    "moto==4.1.14",
+    "moto==4.2.0",
     "networkx==3.1",
     "pydantic==1.10.9",
     "pydash==7.0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ docs = [
     "myst_parser==2.0.0",
     "nbsphinx==0.9.2",
     "sphinx-copybutton==0.5.2",
-    "sphinx==7.2.2",
+    "sphinx==7.2.4",
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = ["pytest-cov==4.1.0", "pytest==7.4.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
     "sphinx==7.2.4",
 ]
 dev = ["pre-commit>=2.12.1"]
-tests = ["pytest-cov==4.1.0", "pytest==7.4.0"]
+tests = ["pytest-cov==4.1.0", "pytest==7.4.0","moto==4.2.0"]
 vis = ["matplotlib", "pydot"]
 fireworks = ["FireWorks"]
 strict = [

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -568,6 +568,8 @@ class Job(MSONable):
         if self.config.expose_store:
             CURRENT_JOB.store = store
 
+        unresolved_input_refs = self.input_references
+
         if self.config.resolve_references:
             self.resolve_args(store=store)
 
@@ -641,7 +643,9 @@ class Job(MSONable):
             "metadata": self.metadata,
             "hosts": self.hosts,
             "name": self.name,
+            "input_references": unresolved_input_refs,
         }
+
         store.update(data, key=["uuid", "index"], save=save)
 
         CURRENT_JOB.reset()

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -569,6 +569,8 @@ class Job(MSONable):
         if self.config.expose_store:
             CURRENT_JOB.store = store
 
+        unresolved_input_refs = self.input_references
+
         if self.config.resolve_references:
             self.resolve_args(store=store)
 
@@ -642,6 +644,7 @@ class Job(MSONable):
             metadata=self.metadata,
             hosts=self.hosts,
             name=self.name,
+            input_references=unresolved_input_refs,
         )
         # Need to do changes to .update method
         store.update(data, key=["uuid", "index"], save=save)

--- a/src/jobflow/core/outputs.py
+++ b/src/jobflow/core/outputs.py
@@ -1,0 +1,67 @@
+"""Define classes related to accessing job and Flow outputs."""
+
+from .store import JobStore
+
+
+class OutputManager:
+    """
+    An :obj:`OutputManager` provides functions for retrieving job outputs.
+
+    It is primarily concerned with identifying the relationships between
+    jobs, and allowing the traversal of the job graph after the job has run.
+
+    Parameters
+    ----------
+    store
+        The JobStore used for retrieving outputs.
+
+    Returns
+    -------
+    OutputManager
+        An OutputManager instance.
+
+    See Also
+    --------
+    JobStore
+    """
+
+    def __init__(self, store: JobStore):
+        self._store = store
+
+    def get_all_jobs_in_flow(self, job_uuid: str):
+        """
+        Retrieve output documents for every job in the flow that contains this job.
+
+        Parameters
+        ----------
+        job_uuid
+            The UUID of the job to start searching from.
+
+        Returns
+        -------
+        List[JobOutputDoc]
+            A list of output documents for the jobs in the containing flow
+        """
+        job_doc = self._store.query_one({"uuid": job_uuid})
+        parent_flow_id = job_doc["hosts"][-1]
+        all_job_docs = list(self._store.query({"hosts": parent_flow_id}))
+        return all_job_docs
+
+    def get_job_parents(self, job_uuid: str):
+        """
+        Retrieve the output documents associated with job parents.
+
+        Parameters
+        ----------
+        job_uuid
+            The UUID of the job whose parent outputs should be
+            retrieved.
+
+        Returns
+        -------
+        List[dict]
+            A list of output documents for the job's parents.
+        """
+        job_doc = self._store.query_one({"uuid": job_uuid})
+        parent_uuids = [r["uuid"] for r in job_doc["input_references"]]
+        return list(self._store.query({"uuid": {"$in": parent_uuids}}))

--- a/src/jobflow/core/outputs.py
+++ b/src/jobflow/core/outputs.py
@@ -1,5 +1,7 @@
 """Define classes related to accessing job and Flow outputs."""
 
+from jobflow.settings import JobflowSettings
+
 from .store import JobStore
 
 
@@ -25,7 +27,10 @@ class OutputManager:
     JobStore
     """
 
-    def __init__(self, store: JobStore):
+    def __init__(self, store: JobStore = None):
+        if store is None:
+            store = JobflowSettings().JOB_STORE
+
         self._store = store
 
     def get_all_jobs_in_flow(self, job_uuid: str):
@@ -63,5 +68,48 @@ class OutputManager:
             A list of output documents for the job's parents.
         """
         job_doc = self._store.query_one({"uuid": job_uuid})
+        # Utilize Hrushikesh's class here instead of using a raw dictionary.
         parent_uuids = [r["uuid"] for r in job_doc["input_references"]]
         return list(self._store.query({"uuid": {"$in": parent_uuids}}))
+
+
+class FlowOutput:
+    """
+    A :obj:`FlowOutput` provides methods for retrieving outputs of jobs in a flow.
+
+    It retains information about the connectedness of jobs and allows the user
+    to retrieve job outputs by navigating the flow graph.
+
+    Parameters
+    ----------
+    store
+        The JobStore used for retrieving outputs.
+
+    Returns
+    -------
+    FlowOutput
+        An FlowOutput instance.
+
+    See Also
+    --------
+    JobStore
+    """
+
+    def __init__(self, flow_uuid: str, store: JobStore = None):
+        if store is None:
+            store = JobflowSettings().JOB_STORE
+
+        self._store = store
+        self.uuid = flow_uuid
+
+    @property
+    def jobs(self):
+        """
+        Returns the outputs of the jobs associated with this flow.
+
+        Returns
+        -------
+        List[dict]
+            A list of output documents for the job's parents.
+        """
+        pass

--- a/src/jobflow/core/outputs.py
+++ b/src/jobflow/core/outputs.py
@@ -1,8 +1,84 @@
 """Define classes related to accessing job and Flow outputs."""
+from __future__ import annotations
 
+from jobflow.schemas.job_store import JobStoreDocument
 from jobflow.settings import JobflowSettings
 
 from .store import JobStore
+
+
+def get_flow_tree_from_host_lists(host_lists) -> dict:
+    """
+    Construct a tree representing flow nesting from by a set of host lists.
+
+    Parameters
+    ----------
+    host_lists
+        A list of lists of strings retrieved from the .hosts attribute on
+        JobStoreDocuments.
+
+    Returns
+    -------
+    Dict
+        A dictionary representing the flow nesting.
+    """
+    flow_parents: dict[str, dict] = {}
+    for hl in host_lists:
+        curr_flow_parents = flow_parents
+        for flow_uuid in reversed(hl):
+
+            if flow_uuid not in curr_flow_parents:
+                curr_flow_parents[flow_uuid] = {}
+
+            curr_flow_parents = curr_flow_parents[flow_uuid]
+    return flow_parents
+
+
+def get_flow_output_from_tree(
+    flow_uuid, flow_tree, parent_flow=None, job_parent_map=None
+):
+    """
+    Construct a FlowOutput from a flow tree.
+
+    Parameters
+    ----------
+    flow_uuid
+        The UUID of the flow containing the flow tree.
+
+    flow_tree
+        The flow tree from which flow outputs should be recursively
+        reconstructed.
+
+    parent_flow
+        A reference to the flow containing this flow, if any.
+
+    job_parent_map
+        A dict mapping flow UUIDs to list of JobStoreDocuments which
+        are contained by those flows.
+
+    Returns
+    -------
+    Dict
+        A dictionary representing the flow nesting.
+    """
+    if len(flow_tree) == 0:
+        output = FlowOutput(flow_uuid, parent_flow=parent_flow)
+    else:
+        output = FlowOutput(flow_uuid, parent_flow=parent_flow)
+        for flow_uuid, sub_flow_tree in flow_tree.items():
+            sub_flow_output = get_flow_output_from_tree(
+                flow_uuid,
+                sub_flow_tree,
+                parent_flow=output,
+                job_parent_map=job_parent_map,
+            )
+            output.add_output(sub_flow_output)
+
+    if job_parent_map is not None:
+        for job_doc in job_parent_map.get(flow_uuid):
+            output.add_output(job_doc)
+
+    return output
 
 
 class OutputManager:
@@ -33,7 +109,7 @@ class OutputManager:
 
         self._store = store
 
-    def get_all_jobs_in_flow(self, job_uuid: str):
+    def construct_flow_from_job(self, job_uuid: str):
         """
         Retrieve output documents for every job in the flow that contains this job.
 
@@ -48,9 +124,29 @@ class OutputManager:
             A list of output documents for the jobs in the containing flow
         """
         job_doc = self._store.query_one({"uuid": job_uuid})
+        if job_doc is None:
+            raise ValueError(f"No jobs found in store with uuid {job_uuid}")
+
         parent_flow_id = job_doc["hosts"][-1]
-        all_job_docs = list(self._store.query({"hosts": parent_flow_id}))
-        return all_job_docs
+        all_job_dicts = list(self._store.query({"hosts": parent_flow_id}))
+        all_job_docs = [JobStoreDocument(**d) for d in all_job_dicts]
+
+        parent_job_flows: dict[str, list[JobStoreDocument]] = {}
+
+        for job_doc in all_job_docs:
+            parent_flow_uuid = job_doc.hosts[0]
+            if parent_flow_uuid not in parent_job_flows:
+                parent_job_flows[parent_flow_uuid] = []
+
+            parent_job_flows[parent_flow_uuid].append(job_doc)
+
+        host_lists = [d.hosts for d in all_job_docs]
+        flow_tree = get_flow_tree_from_host_lists(host_lists)
+
+        top_flow_uuid = next(iter(flow_tree.keys()))
+        return get_flow_output_from_tree(
+            top_flow_uuid, flow_tree[top_flow_uuid], job_parent_map=parent_job_flows
+        )
 
     def get_job_parents(self, job_uuid: str):
         """
@@ -68,9 +164,9 @@ class OutputManager:
             A list of output documents for the job's parents.
         """
         job_doc = self._store.query_one({"uuid": job_uuid})
-        # Utilize Hrushikesh's class here instead of using a raw dictionary.
         parent_uuids = [r["uuid"] for r in job_doc["input_references"]]
-        return list(self._store.query({"uuid": {"$in": parent_uuids}}))
+        raw_docs = list(self._store.query({"uuid": {"$in": parent_uuids}}))
+        return [JobStoreDocument(**d) for d in raw_docs]
 
 
 class FlowOutput:
@@ -95,21 +191,128 @@ class FlowOutput:
     JobStore
     """
 
-    def __init__(self, flow_uuid: str, store: JobStore = None):
+    def __init__(
+        self,
+        flow_uuid: str,
+        containing_flow_output: FlowOutput = None,
+        store: JobStore = None,
+    ):
         if store is None:
             store = JobflowSettings().JOB_STORE
 
         self._store = store
         self.uuid = flow_uuid
+        self.containing_flow = containing_flow_output
+        self._job_outputs: list[JobStoreDocument] = []
+        self._flow_outputs: list[FlowOutput] = []
 
-    @property
-    def jobs(self):
+    def add_output(self, output: FlowOutput | JobStoreDocument) -> None:
         """
-        Returns the outputs of the jobs associated with this flow.
+        Add an output to the record of outputs contained in this flow.
+
+        Output can be either a FlowOutput or a JobStoreDocument.
+
+        Returns
+        -------
+        None
+
+        """
+        if type(output) == FlowOutput:
+            self._flow_outputs.append(output)
+        elif type(output) == JobStoreDocument:
+            self._job_outputs.append(output)
+
+    def immediate_job_outputs(self) -> list[JobStoreDocument]:
+        """
+        Retrieve the outputs of the jobs which are immediate children of this flow.
+
+        Returns
+        -------
+        List[JobStoreDocument]
+            A list of output documents.
+        """
+        return self._job_outputs
+
+    def all_job_outputs(self) -> list[JobStoreDocument]:
+        """
+        Recursively retrieve job outputs in this flow.
+
+        Returns
+        -------
+        List[JobStoreDocument]
+            A list of output documents.
+        """
+        outputs = self.immediate_job_outputs()
+        for flow_output in self.flow_outputs():
+            subflow_outputs = flow_output.all_job_outputs()
+            outputs = [*outputs, *subflow_outputs]
+        return outputs
+
+    def flow_outputs(self) -> list[FlowOutput]:
+        """
+        Retrieve the outputs of flows inside this flow.
+
+        Returns
+        -------
+        List[FlowOutput]
+            A list of FlowOutput objects.
+        """
+        return self._flow_outputs
+
+    def get_job_prerequisites(
+        self, job_doc: JobStoreDocument
+    ) -> list[JobStoreDocument]:
+        """
+        Retrieve the outputs of the jobs referenced as inputs in the provided job.
+
+        Parameters
+        ----------
+        job_doc
+            The job document whose parents should be retrieved.
+
+        Returns
+        -------
+        List[JobStoreDocument]
+            A list of job output documents.
+        """
+        prereq_uuids = [ref.uuid for ref in job_doc.input_references]
+        inputs = [self.get_job_document(u) for u in prereq_uuids]
+        return inputs
+
+    def containing_flow_list(self) -> list[FlowOutput]:
+        """
+        Retrieve the list of flows in which this flow is nested.
+
+        Similar to the hosts property of a JobStoreDocument.
 
         Returns
         -------
         List[dict]
-            A list of output documents for the job's parents.
+            A list of output documents.
         """
-        pass
+        return [self.containing_flow, *self.containing_flow.containing_flow_list()]
+
+    def get_job_document(self, job_uuid) -> JobStoreDocument | None:
+        """
+        Retrieve the output document for a job in this flow or one of its children.
+
+        Parameters
+        ----------
+        job_doc
+            The job document which should be retrieved.
+
+        Returns
+        -------
+        List[dict]
+            A list of output documents.
+        """
+        filtered = [d for d in self._job_outputs if d.uuid == job_uuid]
+        if len(filtered) > 0:
+            return filtered[0]
+        else:
+            for flow in self.flow_outputs():
+                retrieved = flow.get_job_document(job_uuid)
+                if retrieved is not None:
+                    return retrieved
+
+            return None

--- a/src/jobflow/schemas/job_store.py
+++ b/src/jobflow/schemas/job_store.py
@@ -4,6 +4,8 @@ import typing
 
 from pydantic import BaseModel, Field
 
+from jobflow.core.reference import OutputReference
+
 
 class JobStoreDocument(BaseModel):
     """A Pydantic model for Jobstore document."""
@@ -31,4 +33,7 @@ class JobStoreDocument(BaseModel):
     name: str = Field(
         None,
         description="The name of the job.",
+    )
+    input_references: typing.List[OutputReference] = Field(
+        default_factory=list, description="The list of input references for this job"
     )

--- a/tests/core/test_outputs.py
+++ b/tests/core/test_outputs.py
@@ -1,0 +1,122 @@
+import pytest
+
+from jobflow import job
+
+
+@pytest.fixture
+def add_job():
+    @job
+    def add(a, b):
+        return a + b
+
+    return add
+
+
+def test_retrieves_jobs_in_single_flow(memory_jobstore, add_job):
+    from jobflow import Flow
+    from jobflow.core.outputs import OutputManager
+    from jobflow.managers.local import run_locally
+
+    j1 = add_job(1, 2)
+    j2 = add_job(2, 3)
+
+    flow = Flow([j1, j2])
+
+    run_locally(flow, store=memory_jobstore)
+
+    manager = OutputManager(memory_jobstore)
+
+    all_output_docs = manager.get_all_jobs_in_flow(j1.uuid)
+    all_uuids = {d["uuid"] for d in all_output_docs}
+    assert len(all_output_docs) == 2
+
+    assert j1.uuid in all_uuids
+    assert j2.uuid in all_uuids
+
+
+def test_retrieves_jobs_in_nested_flows(memory_jobstore, add_job):
+    from jobflow import Flow
+    from jobflow.core.outputs import OutputManager
+    from jobflow.managers.local import run_locally
+
+    j1 = add_job(1, 2)
+    j3 = add_job(3, 6)
+    j4 = add_job(4, j3.output)
+    subflow = Flow([j3, j4], output=j4.output)
+
+    j2 = add_job(2, subflow.output)
+
+    flow = Flow([j1, subflow, j2], output=j2.output)
+    run_locally(flow, store=memory_jobstore)
+
+    all_uuids = {j1.uuid, j2.uuid, j3.uuid, j4.uuid}
+
+    mgr = OutputManager(memory_jobstore)
+
+    # Assert returned jobs are the same regardless
+    # of where you start
+
+    from_j1 = mgr.get_all_jobs_in_flow(j1.uuid)
+    j1_uuids = {p["uuid"] for p in from_j1}
+    assert j1_uuids == all_uuids
+
+    from_j2 = mgr.get_all_jobs_in_flow(j2.uuid)
+    j2_uuids = {p["uuid"] for p in from_j2}
+    assert j2_uuids == all_uuids
+
+    from_j3 = mgr.get_all_jobs_in_flow(j3.uuid)
+    j3_uuids = {p["uuid"] for p in from_j3}
+    assert j3_uuids == all_uuids
+
+    from_j4 = mgr.get_all_jobs_in_flow(j4.uuid)
+    j4_uuids = {p["uuid"] for p in from_j4}
+    assert j4_uuids == all_uuids
+
+
+def test_retrieves_job_parents(memory_jobstore, add_job):
+    from jobflow import Flow
+    from jobflow.core.outputs import OutputManager
+    from jobflow.managers.local import run_locally
+
+    j1 = add_job(1, 2)
+    j2 = add_job(2, j1.output)
+    j3 = add_job(j1.output, j2.output)
+
+    flow = Flow([j1, j2, j3])
+    run_locally(flow, store=memory_jobstore)
+
+    mgr = OutputManager(memory_jobstore)
+    j1_parents = mgr.get_job_parents(j1.uuid)
+    assert len(j1_parents) == 0
+
+    j2_parents = mgr.get_job_parents(j2.uuid)
+    assert len(j2_parents) == 1
+    assert j2_parents[0]["uuid"] == j1.uuid
+
+    j3_parents = mgr.get_job_parents(j3.uuid)
+    assert len(j3_parents) == 2
+    j3_parent_uuids = {p["uuid"] for p in j3_parents}
+    assert j1.uuid in j3_parent_uuids
+    assert j2.uuid in j3_parent_uuids
+
+
+def test_retrieves_job_parents_nested_flows(memory_jobstore, add_job):
+    from jobflow import Flow
+    from jobflow.core.outputs import OutputManager
+    from jobflow.managers.local import run_locally
+
+    j1 = add_job(1, 2)
+    j3 = add_job(3, 6)
+    j4 = add_job(4, j3.output)
+    subflow = Flow([j3, j4], output=j4.output)
+
+    j2 = add_job(2, subflow.output)
+
+    flow = Flow([j1, subflow, j2], output=j2.output)
+    run_locally(flow, store=memory_jobstore)
+
+    mgr = OutputManager(memory_jobstore)
+    j2_parents = mgr.get_job_parents(j2.uuid)
+    j2_parent_uuids = [p["uuid"] for p in j2_parents]
+    assert len(j2_parent_uuids) == 1
+    assert j2_parent_uuids[0] == j4.uuid

--- a/tests/core/test_outputs.py
+++ b/tests/core/test_outputs.py
@@ -120,3 +120,31 @@ def test_retrieves_job_parents_nested_flows(memory_jobstore, add_job):
     j2_parent_uuids = [p["uuid"] for p in j2_parents]
     assert len(j2_parent_uuids) == 1
     assert j2_parent_uuids[0] == j4.uuid
+
+
+def test_constructs_flow_tree():
+    from jobflow.core.outputs import get_flow_tree_from_host_lists
+
+    host_lists = [["c", "b", "a"], ["b", "a"], ["d", "b", "a"]]
+
+    flow_tree = get_flow_tree_from_host_lists(host_lists)
+
+    assert len(flow_tree) == 1
+    assert "a" in flow_tree
+
+    a_direct_subflows = flow_tree.get("a")
+
+    assert len(a_direct_subflows) == 1
+    assert "b" in a_direct_subflows
+
+    b_direct_subflows = a_direct_subflows.get("b")
+
+    assert len(b_direct_subflows) == 2
+    assert "c" in b_direct_subflows
+    assert "d" in b_direct_subflows
+
+    c_direct_subflows = b_direct_subflows.get("c")
+    d_direct_subflows = b_direct_subflows.get("d")
+
+    assert len(c_direct_subflows) == 0
+    assert len(d_direct_subflows) == 0

--- a/tests/core/test_outputs.py
+++ b/tests/core/test_outputs.py
@@ -1,10 +1,10 @@
 import pytest
 
-from jobflow import job
-
 
 @pytest.fixture
 def add_job():
+    from jobflow import job
+
     @job
     def add(a, b):
         return a + b


### PR DESCRIPTION
## Summary

This is a WIP PR addressing #374 . I implemented the storage of input references in the JobStoreDocument (from Hrushikesh's PR ([here](https://github.com/materialsproject/jobflow/pull/424)).

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [X] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply
`cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
