### PR TITLE
Make ensure_success apply to replace/detour/addition jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ docs = [
     "sphinx==7.2.4",
 ]
 dev = ["pre-commit>=2.12.1"]
-tests = ["pytest-cov==4.1.0", "pytest==7.4.0"]
+tests = ["pytest-cov==4.1.0", "pytest==7.4.0","moto==4.2.0"]
 vis = ["matplotlib", "pydot"]
 fireworks = ["FireWorks"]
 strict = [

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -119,19 +119,23 @@ def run_locally(
             stop_jobflow = True
             return False
 
+        diversion_responses = []
         if response.replace is not None:
             # first run any restarts
-            _run(response.replace)
+            diversion_responses.append(_run(response.replace))
 
         if response.detour is not None:
             # next any detours
-            _run(response.detour)
+            diversion_responses.append(_run(response.detour))
 
         if response.addition is not None:
             # finally any additions
-            _run(response.addition)
+            diversion_responses.append(_run(response.addition))
 
-        return response
+        if not all(diversion_responses):
+            return False
+        else:
+            return response
 
     def _get_job_dir():
         if create_folders:
@@ -143,7 +147,6 @@ def run_locally(
             return root_dir
 
     def _run(root_flow):
-        job: jobflow.Job
         for job, parents in root_flow.iterflow():
             job_dir = _get_job_dir()
             with cd(job_dir):

--- a/tests/managers/conftest.py
+++ b/tests/managers/conftest.py
@@ -235,6 +235,82 @@ def error_flow(error_job, simple_job):
 
 
 @pytest.fixture(scope="session")
+def error_detour_job(error_job):
+    from jobflow import Response, job
+
+    global error_detour_func
+
+    @job
+    def error_detour_func(message):
+        return Response(output=message + "_end", detour=error_job())
+
+    return error_detour_func
+
+
+@pytest.fixture(scope="session")
+def error_detour_flow(error_detour_job, simple_job):
+    from jobflow import Flow
+
+    def _gen():
+        error = error_detour_job("detour")
+        simple1 = simple_job(error.output)
+        return Flow([error, simple1])
+
+    return _gen
+
+
+@pytest.fixture(scope="session")
+def error_replace_job(error_job):
+    from jobflow import Response, job
+
+    global error_replace_func
+
+    @job
+    def error_replace_func(message):
+        return Response(output=message + "_end", replace=error_job())
+
+    return error_replace_func
+
+
+@pytest.fixture(scope="session")
+def error_replace_flow(error_replace_job, simple_job):
+    from jobflow import Flow
+
+    def _gen():
+        error = error_replace_job("replace")
+        simple_job(error.output)
+        print(type(error))
+        return Flow([error])
+
+    return _gen
+
+
+@pytest.fixture(scope="session")
+def error_addition_job(error_job):
+    from jobflow import Response, job
+
+    global error_addition_func
+
+    @job
+    def error_addition_func(message):
+        return Response(output=message + "_end", addition=error_job())
+
+    return error_addition_func
+
+
+@pytest.fixture(scope="session")
+def error_addition_flow(error_addition_job, simple_job):
+    from jobflow import Flow
+
+    def _gen():
+        error = error_addition_job("addition")
+        simple1 = simple_job(error.output)
+        return Flow([error, simple1])
+
+    return _gen
+
+
+@pytest.fixture(scope="session")
 def stored_data_job():
     from jobflow import Response, job
 

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -323,6 +323,59 @@ def test_error_flow(memory_jobstore, clean_dir, error_flow, capsys):
         run_locally(flow, store=memory_jobstore, ensure_success=True)
 
 
+def test_ensure_success_with_replace(memory_jobstore, error_replace_flow, capsys):
+    from jobflow import run_locally
+
+    flow = error_replace_flow()
+    print(type(flow))
+
+    responses = run_locally(flow, store=memory_jobstore)
+
+    # check responses has been filled with the replaced
+    # job's output
+    assert len(responses) == 1
+
+    captured = capsys.readouterr()
+    assert "error_func failed with exception" in captured.out
+
+    with pytest.raises(RuntimeError):
+        run_locally(flow, store=memory_jobstore, ensure_success=True)
+
+
+def test_ensure_success_with_detour(error_detour_flow, memory_jobstore, capsys):
+    from jobflow import run_locally
+
+    flow = error_detour_flow()
+
+    responses = run_locally(flow, store=memory_jobstore)
+
+    # check responses has been filled with the detour output
+    assert len(responses) == 1
+
+    captured = capsys.readouterr()
+    assert "error_func failed with exception" in captured.out
+
+    with pytest.raises(RuntimeError):
+        run_locally(flow, store=memory_jobstore, ensure_success=True)
+
+
+def test_ensure_success_with_addition(error_addition_flow, memory_jobstore, capsys):
+    from jobflow import run_locally
+
+    flow = error_addition_flow()
+
+    responses = run_locally(flow, store=memory_jobstore)
+
+    # check responses has been filled with the addition output
+    assert len(responses) == 1
+
+    captured = capsys.readouterr()
+    assert "error_func failed with exception" in captured.out
+
+    with pytest.raises(RuntimeError):
+        run_locally(flow, store=memory_jobstore, ensure_success=True)
+
+
 def test_stored_data_flow(memory_jobstore, clean_dir, stored_data_flow, capsys):
     from jobflow import run_locally
 

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -338,7 +338,7 @@ def test_ensure_success_with_replace(memory_jobstore, error_replace_flow, capsys
     captured = capsys.readouterr()
     assert "error_func failed with exception" in captured.out
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Flow did not finish running successfully"):
         run_locally(flow, store=memory_jobstore, ensure_success=True)
 
 
@@ -355,7 +355,7 @@ def test_ensure_success_with_detour(error_detour_flow, memory_jobstore, capsys):
     captured = capsys.readouterr()
     assert "error_func failed with exception" in captured.out
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Flow did not finish running successfully"):
         run_locally(flow, store=memory_jobstore, ensure_success=True)
 
 
@@ -372,7 +372,7 @@ def test_ensure_success_with_addition(error_addition_flow, memory_jobstore, caps
     captured = capsys.readouterr()
     assert "error_func failed with exception" in captured.out
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Flow did not finish running successfully"):
         run_locally(flow, store=memory_jobstore, ensure_success=True)
 
 


### PR DESCRIPTION
## Summary

Addresses #423 by keeping track of the results of running detour/replace/addition job and insisting they are all truth-y if ensure_success is True.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [X] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [X] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [X] Tests have been added for any new functionality or bug fixes.
- [X] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply
`cp pre-commit .git/hooks` and a check will be run prior to allowing commits.
