### PR TITLE
Use `.__wrapped__` instead of a `.original`

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -185,13 +185,15 @@ def job(method: Callable = None, **job_kwargs):
                 # this function
                 met = getattr(args[0], func.__name__, None)
                 if met:
-                    # if so, check to see if that function ha been wrapped and
+                    # if so, check to see if that function has been wrapped and
                     # whether the unwrapped function is the same as this function
                     wrap = getattr(met, "__func__", None)
                     if getattr(wrap, "__wrapped__", None) is func:
                         # Ah ha. The function is a bound method.
                         f = met
                         args = args[1:]
+
+            get_job.__wrapped__ = func
 
             return Job(
                 function=f, function_args=args, function_kwargs=kwargs, **job_kwargs

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -188,7 +188,7 @@ def job(method: Callable = None, **job_kwargs):
                     # if so, check to see if that function ha been wrapped and
                     # whether the unwrapped function is the same as this function
                     wrap = getattr(met, "__func__", None)
-                    if getattr(wrap, "original", None) is func:
+                    if getattr(wrap, "__wrapped__", None) is func:
                         # Ah ha. The function is a bound method.
                         f = met
                         args = args[1:]
@@ -196,8 +196,6 @@ def job(method: Callable = None, **job_kwargs):
             return Job(
                 function=f, function_args=args, function_kwargs=kwargs, **job_kwargs
             )
-
-        get_job.original = func
 
         if desc:
             # rewrap staticmethod or classmethod decorators

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -197,8 +197,6 @@ def job(method: Callable = None, **job_kwargs):
                 function=f, function_args=args, function_kwargs=kwargs, **job_kwargs
             )
 
-        get_job.__wrapped__ = func
-
         if desc:
             # rewrap staticmethod or classmethod decorators
             get_job = desc(get_job)

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -193,11 +193,11 @@ def job(method: Callable = None, **job_kwargs):
                         f = met
                         args = args[1:]
 
-            get_job.__wrapped__ = func
-
             return Job(
                 function=f, function_args=args, function_kwargs=kwargs, **job_kwargs
             )
+
+        get_job.__wrapped__ = func
 
         if desc:
             # rewrap staticmethod or classmethod decorators


### PR DESCRIPTION
When creating a `Job`, jobflow checks to see if the function is wrapped by looking for a custom-made `.original` attribute. This should be the same as the already-created `.__wrapped__` attribute from `@functools.wraps()` so we should just use that.

```python
import jobflow as jf

@jf.job
def add(a, b):
    return a+b

assert add.__wrapped__ == add.original
```

The above indicates that they are the same.

Sadly, I don't know where I'm going wrong though in this PR :( I'm probably not understanding the logic fully...