### PR TITLE
Add support for Pydantic 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "autodoc_pydantic==1.9.0",
+    "autodoc_pydantic==2.0.1",
     "furo==2023.9.10",
     "ipython==8.15.0",
     "myst_parser==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ extend-ignore = "E203, W503, E501, F401, RST21"
 min-python-version = "3.8.0"
 docstring-convention = "numpy"
 rst-roles = "class, func, ref, obj"
+extend-exclude = ["tests"]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ extend-ignore = "E203, W503, E501, F401, RST21"
 min-python-version = "3.8.0"
 docstring-convention = "numpy"
 rst-roles = "class, func, ref, obj"
-extend-exclude = ["tests"]
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -145,4 +144,4 @@ isort.known-first-party = ["jobflow"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
-"**/tests/*" = ["D"]
+"**/tests/*" = ["D", "B018]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,11 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "PyYAML",
-    "maggma>=0.38.1",
-    "monty>=2021.5.9",
+    "maggma>=0.57.0",
+    "monty>=2023.9.25",
     "networkx",
-    "pydantic<2",
+    "pydantic>=2.4.1",
+    "pydantic-settings>=2.0.3",
     "pydash",
 ]
 
@@ -52,12 +53,13 @@ fireworks = ["FireWorks"]
 strict = [
     "FireWorks==2.0.3",
     "PyYAML==6.0.1",
-    "maggma==0.56.0",
+    "maggma==0.57.0",
     "matplotlib==3.7.2",
     "monty==2023.9.25",
     "moto==4.2.4",
     "networkx==3.1",
-    "pydantic==1.10.9",
+    "pydantic==2.4.1",
+    "pydantic-settings==2.0.3",
     "pydash==7.0.6",
     "pydot==1.4.2",
     "typing-extensions==4.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,4 +144,4 @@ isort.known-first-party = ["jobflow"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
-"**/tests/*" = ["D", "B018]
+"**/tests/*" = ["D", "B018"]

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -8,7 +8,7 @@ from typing import Any, Sequence
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable, jsanitize
 from pydantic import BaseModel
-from pydantic.utils import lenient_issubclass
+from pydantic.v1.utils import lenient_issubclass
 
 from jobflow.utils.enum import ValueEnum
 

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -503,7 +503,7 @@ def validate_schema_access(
         raise AttributeError(f"{schema.__name__} does not have attribute '{item}'.")
 
     subschema = None
-    item_type = schema.__fields__[item].outer_type_
+    item_type = schema.model_fields[item].annotation
     if lenient_issubclass(item_type, BaseModel):
         subschema = item_type
 

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from maggma.stores import MemoryStore
-from pydantic import model_validator, Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from jobflow import JobStore

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 from maggma.stores import MemoryStore
 from pydantic import model_validator, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from jobflow import JobStore
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
 DEFAULT_CONFIG_FILE_PATH = Path("~/.jobflow.yaml").expanduser().as_posix()
 

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -5,9 +5,10 @@ from collections import defaultdict
 from pathlib import Path
 
 from maggma.stores import MemoryStore
-from pydantic import BaseSettings, Field, root_validator
+from pydantic import model_validator, Field
 
 from jobflow import JobStore
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 DEFAULT_CONFIG_FILE_PATH = Path("~/.jobflow.yaml").expanduser().as_posix()
 
@@ -118,13 +119,10 @@ class JobflowSettings(BaseSettings):
         "%Y-%m-%d-%H-%M-%S-%f",
         description="Date stamp format used to create directories",
     )
+    model_config = SettingsConfigDict(env_prefix="jobflow_")
 
-    class Config:
-        """Pydantic config settings."""
-
-        env_prefix = "jobflow_"
-
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def load_default_settings(cls, values):
         """
         Load settings from file or environment variables.

--- a/tests/core/test_reference.py
+++ b/tests/core/test_reference.py
@@ -161,7 +161,7 @@ def test_schema():
     class MediumSchema(BaseModel):
         s: str
         nested: InnerSchema
-        nested_opt: Optional[InnerSchema]
+        nested_opt: Optional[InnerSchema] = None
         nested_u: Union[InnerSchema, dict]
         nested_l: List[InnerSchema]
         nested_d: Dict[str, InnerSchema]

--- a/tests/core/test_reference.py
+++ b/tests/core/test_reference.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 import pytest
 
@@ -161,7 +161,7 @@ def test_schema():
     class MediumSchema(BaseModel):
         s: str
         nested: InnerSchema
-        nested_opt: Optional[InnerSchema] = None
+        nested_opt: InnerSchema = None
         nested_u: Union[InnerSchema, dict]
         nested_l: List[InnerSchema]
         nested_d: Dict[str, InnerSchema]

--- a/tests/core/test_reference.py
+++ b/tests/core/test_reference.py
@@ -184,25 +184,25 @@ def test_schema():
     assert new_ref.output_schema is None
 
     with pytest.raises(AttributeError):
-        assert ref.a.uuid == "123"
+        ref.a.uuid
 
     with pytest.raises(AttributeError):
-        assert ref["a"].uuid == "123"
+        ref["a"].uuid
 
     with pytest.raises(AttributeError):
-        assert ref[1].uuid == "123"
+        ref[1].uuid
 
     # check valid nested schemas
     assert ref.nested.s.uuid == "123"
     with pytest.raises(AttributeError):
-        assert ref.nested.m.uuid == "123"
+        ref.nested.m.uuid
     assert ref.nested.nested.n.uuid == "123"
     with pytest.raises(AttributeError):
-        assert ref.nested.nested.m.uuid == "123"
+        ref.nested.nested.m.uuid
 
     assert ref.nested.nested_opt.n.uuid == "123"
     with pytest.raises(AttributeError):
-        assert ref.nested.nested_opt.m.uuid == "123"
+        ref.nested.nested_opt.m.uuid
 
     # Union, List and Dict are currently not recognized by their inner type
     # but check that there is no problem with them


### PR DESCRIPTION
@utf: As you likely saw, Pydantic 2 introduced many new features and changes. In an effort to support Pydantic 2, much of the MP software stack has now been modified accordingly. With maggma, emmet, and monty now supporting Pydantic 2, I have updated Jobflow to match.

Tagging @munrojm who initiated this switch for the rest of the MP stack. I haven't gotten all the tests to pass yet --- suggestions are very welcome!

Closes #422. 