### PR TITLE
Add `__getitem__` magic method for `Job`

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -403,6 +403,22 @@ class Job(MSONable):
     def __hash__(self) -> int:
         """Get the hash of the job."""
         return hash(self.uuid)
+    
+    def __getitem__(self, k: Any) -> OutputReference:
+        """
+        Convenience function for parsing the output of a Job.
+
+        Parameters
+        ----------
+        k
+            The index key or index.
+        
+        Returns
+        -------
+        OutputReference
+            The equivalent of `Job.output[k]`
+        """
+        return self.output[k]
 
     @property
     def input_references(self) -> tuple[jobflow.OutputReference, ...]:

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1012,3 +1012,24 @@ def test_flow_repr():
     assert len(lines) == len(flow_repr)
     for expected, line in zip(lines, flow_repr):
         assert line.startswith(expected), f"{line=} doesn't start with {expected=}"
+
+def test_get_item():
+    from jobflow import Flow, job, run_locally
+
+    @job
+    def make_str(s):
+        return {"hello": s}
+    
+    @job
+    def capitalize(s):
+        return s.upper()
+    
+
+    job1 = make_str("world")
+    job2 = capitalize(job1["hello"])
+    
+    
+    flow = Flow([job1, job2])
+        
+    responses = run_locally(flow, ensure_success=True)
+    assert responses[job2.uuid][1].output == "WORLD"

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -1272,6 +1272,7 @@ def test_update_config(memory_jobstore):
 
 def test_job_magic_methods():
     from jobflow import Job
+    from jobflow.reference import OutputReference
 
     # prepare test jobs
     job1 = Job(function=sum, function_args=([1, 2],))
@@ -1296,3 +1297,9 @@ def test_job_magic_methods():
 
     # test __hash__
     assert hash(job1) != hash(job2) != hash(job3)
+
+    # test __getitem__
+    assert isinstance(job1["test"], OutputReference)
+    assert isinstance(job1[1], OutputReference)
+    assert job1["test"].attributes == (("i", "test"))
+    assert job1[1].attributes == (("a", 1))


### PR DESCRIPTION
## Summary

Following in @janosh's footsteps, I propose a `__getitem__` magic method for `Job`.  such that if you index a `Job` object by a key (as if it were a dictionary) or an index (as if it were a list), the `.output` is already called for the user and the `OutputReference` is returned.

## Motivation

Consider these two toy functions:

```python
@job
def make_str(s):
    return {"hello": s}

@job
def capitalize(s):
    return s.upper()
```

If you want to make a `Flow` of them, you have to currently do:

```python
from jobflow import Flow

job1 = make_str("world")
job2 = capitalize(job1.output["hello"])
flow = Flow([job1, job2])
```

However, new users to Jobflow often stumble on this in my experience because they expect to be able to do:

```python
from jobflow import Flow

job1 = make_str("world")
job2 = capitalize(job1["hello"])
flow = Flow([job1, job2])
```