### PR TITLE
JOSS Paper: Reduce line-spacing in code blocks

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,7 +20,10 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - uses: pre-commit/action@v3.0.0
+      - name: Run pre-commit
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure
 
   test:
     services:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black]
-        exclude: README.md
+        exclude: [README.md, paper/paper.md]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: blacken-docs
         additional_dependencies: [black]
-        exclude: [README.md, paper/paper.md]
+        exclude: ^(README.md|paper/paper.md)$
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -100,16 +100,13 @@ As a simple demonstration, the example below shows how one can construct a simpl
 ```python
 from jobflow import Flow, job, run_locally
 
-
 @job
 def add(a, b):
     return a + b
 
-
 @job
 def multiply(a, b):
     return a * b
-
 
 job1 = add(1, 2)  # 1 + 2 = 3
 job2 = multiply(job1.output, 3)  # 3 * 3 = 9
@@ -128,22 +125,18 @@ Beyond the typical acyclic graph of jobs, Jobflow fully supports dynamic workflo
 from random import randint
 from jobflow import Flow, Response, job, run_locally
 
-
 @job
 def add(a, b):
     return a + b
-
 
 @job
 def make_list(val):
     return [val] * randint(2, 6)
 
-
 @job
 def add_distributed(vals, c):
     jobs = [add(val, c) for val in vals]
     return Response(replace=Flow(jobs))
-
 
 job1 = add(1, 2)  # 1 + 2 = 3
 job2 = make_list(job1.output)  # e.g., [3, 3, 3]
@@ -168,7 +161,6 @@ from dataclasses import dataclass
 from jobflow import job, Flow, Maker
 from jobflow.managers.local import run_locally
 
-
 @dataclass
 class ExponentiateMaker(Maker):
     name: str = "Exponentiate"
@@ -177,7 +169,6 @@ class ExponentiateMaker(Maker):
     @job
     def make(self, a):
         return a**self.exponent
-
 
 job1 = ExponentiateMaker().make(a=2)  # 2**2 = 4
 job2 = ExponentiateMaker(exponent=3).make(job1.output)  # 4**3 = 64


### PR DESCRIPTION
## Summary

The code-blocks have two line breaks in many places, in accordance with `black`. However, the generous line-spacing is somewhat bothersome in a journal article format. I had intended there to be only one line break, but I think Alex's text editor may have auto-reformatted it upon upload. This PR reverts back to the single line-break format I had intended.

Partially addresses (but does not close) #453.

@janosh: Could you please merge this too? Thanks!

Edit: How can we have the lint test skip the `paper.md` file altogether?