### PR TITLE
Bump minimum Python version to 3.9

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
           cache: pip
           cache-dependency-path: pyproject.toml
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ default_language_version:
 exclude: "^src/atomate2/vasp/schemas/calc_types/"
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.282
+    rev: v0.0.292
     hooks:
       - id: ruff
         args: [--fix]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: fix-encoding-pragma
@@ -16,11 +16,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.16.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black]
@@ -46,7 +46,7 @@ repos:
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.6.0
     hooks:
       - id: mypy
         files: ^src/
@@ -55,7 +55,7 @@ repos:
           - types-pkg_resources==0.1.2
           - types-paramiko
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.6
     hooks:
       - id: codespell
         stages: [commit, commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,5 @@ repos:
     hooks:
       - id: codespell
         stages: [commit, commit-msg]
-        args: [--ignore-words-list, "titel,statics,ba,nd,te"]
+        args: [--ignore-words-list, "titel,statics,ba,nd,te,atomate"]
         types_or: [python, rst, markdown]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # jobflow
 
-<a href="https://github.com/materialsproject/jobflow/actions?query=workflow%3Atesting"><img alt="code coverage" src="https://img.shields.io/github/actions/workflow/status/materialsproject/jobflow/testing.yml?branch=main&label=tests"></a>
-<a href="https://codecov.io/gh/materialsproject/jobflow/"><img alt="code coverage" src="https://img.shields.io/codecov/c/gh/materialsproject/jobflow/main"></a>
-<a href="https://pypi.org/project/jobflow"><img alt="pypi version" src="https://img.shields.io/pypi/v/jobflow?color=blue"></a>
-<img alt="supported python versions" src="https://img.shields.io/pypi/pyversions/jobflow">
+[![tests](https://img.shields.io/github/actions/workflow/status/materialsproject/jobflow/testing.yml?branch=main&label=tests)](https://github.com/materialsproject/jobflow/actions?query=workflow%3Atesting)
+[![code coverage](https://img.shields.io/codecov/c/gh/materialsproject/jobflow/main)](https://codecov.io/gh/materialsproject/jobflow/)
+[![pypi version](https://img.shields.io/pypi/v/jobflow?color=blue)](https://pypi.org/project/jobflow/)
+![supported python versions](https://img.shields.io/pypi/pyversions/jobflow)
 
 [Documentation](https://materialsproject.github.io/jobflow/) | [PyPI](https://pypi.org/project/jobflow/) | [GitHub](https://github.com/materialsproject/jobflow)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ the jobs is determined automatically and can be visualised using the flow graph.
 
 ## Installation
 
-The jobflow is a Python 3.8+ library and can be installed using pip.
+`jobflow` is a Python 3.9+ library and can be installed using `pip`.
 
 ```bash
 pip install jobflow

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,7 @@ html_title = "jobflow"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/3.9", None),
     "matplotlib": ("http://matplotlib.org", None),
     "networkx": ("https://networkx.org/documentation/stable/", None),
     "monty": ("https://materialsvirtuallab.github.io/monty/", None),

--- a/examples/replace.py
+++ b/examples/replace.py
@@ -1,6 +1,5 @@
 """A demonstration of how to use dynamic workflows with replace."""
 
-from typing import List
 
 from jobflow import Flow, job, run_locally
 
@@ -29,7 +28,7 @@ def time_website(website: str):
 
 
 @job
-def start_timing_jobs(websites: List[str]):
+def start_timing_jobs(websites: list[str]):
     """Time a list of websites."""
     from jobflow.core.job import Response
 
@@ -44,7 +43,7 @@ def start_timing_jobs(websites: List[str]):
 
 
 @job
-def sum_times(times: List[float]):
+def sum_times(times: list[float]):
     """Sum a list of loading times."""
     return sum(times)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,22 +17,21 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.9",
     "Topic :: Database :: Front-Ends",
     "Topic :: Other/Nonlisted Topic",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "PyYAML",
     "maggma>=0.57.0",
     "monty>=2023.9.25",
     "networkx",
-    "pydantic>=2.0.1",
     "pydantic-settings>=2.0.3",
+    "pydantic>=2.0.1",
     "pydash",
 ]
 
@@ -47,7 +46,7 @@ docs = [
     "sphinx==7.2.6",
 ]
 dev = ["pre-commit>=2.12.1"]
-tests = ["pytest-cov==4.1.0", "pytest==7.4.2", "moto==4.2.5"]
+tests = ["moto==4.2.5", "pytest-cov==4.1.0", "pytest==7.4.2"]
 vis = ["matplotlib", "pydot"]
 fireworks = ["FireWorks"]
 strict = [
@@ -58,8 +57,8 @@ strict = [
     "monty==2023.9.25",
     "moto==4.2.5",
     "networkx==3.1",
-    "pydantic==2.4.2",
     "pydantic-settings==2.0.3",
+    "pydantic==2.4.2",
     "pydash==7.0.6",
     "pydot==1.4.2",
     "typing-extensions==4.8.0",
@@ -83,7 +82,7 @@ max-line-length = 88
 max-doc-length = 88
 select = "C, E, F, W, B"
 extend-ignore = "E203, W503, E501, F401, RST21"
-min-python-version = "3.8.0"
+min-python-version = "3.9.0"
 docstring-convention = "numpy"
 rst-roles = "class, func, ref, obj"
 
@@ -119,7 +118,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 ignore-init-module-imports = true
 select = [
     "B",   # flake8-bugbear
@@ -144,4 +143,4 @@ isort.known-first-party = ["jobflow"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
-"**/tests/*" = ["D", "B018"]
+"**/tests/*" = ["B018", "D"]

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections.abc import Sequence
 from copy import deepcopy
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from monty.json import MSONable
 
@@ -14,7 +15,8 @@ from jobflow.core.reference import find_and_get_references
 from jobflow.utils import ValueEnum, contains_flow_or_job, suuid
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator
+    from collections.abc import Iterator
+    from typing import Any, Callable
 
     from networkx import DiGraph
 

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -14,7 +14,8 @@ from jobflow.schemas.job_output_schema import JobStoreDocument
 from jobflow.utils.uuid import suuid
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Callable, Hashable, Sequence
+    from collections.abc import Hashable, Sequence
+    from typing import Any, Callable
 
     from networkx import DiGraph
     from pydantic import BaseModel

--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import typing
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable, jsanitize
 from pydantic import BaseModel

--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -12,15 +12,16 @@ from jobflow.schemas.job_output_schema import JobStoreDocument
 from jobflow.utils.find import get_root_locations
 
 if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
     from enum import Enum
     from pathlib import Path
-    from typing import Any, Dict, Iterator, List, Optional, Type, Union
+    from typing import Any, Optional, Union
 
     from maggma.core import Sort
 
-    obj_type = Union[str, Enum, Type[MSONable], List[Union[Enum, str, Type[MSONable]]]]
-    save_type = Optional[Dict[str, obj_type]]
-    load_type = Union[bool, Dict[str, Union[bool, obj_type]]]
+    obj_type = Union[str, Enum, type[MSONable], list[Union[Enum, str, type[MSONable]]]]
+    save_type = Optional[dict[str, obj_type]]
+    load_type = Union[bool, dict[str, Union[bool, obj_type]]]
 
 
 T = typing.TypeVar("T", bound="JobStore")

--- a/src/jobflow/managers/fireworks.py
+++ b/src/jobflow/managers/fireworks.py
@@ -7,7 +7,7 @@ import typing
 from fireworks import FiretaskBase, Firework, FWAction, Workflow, explicit_serialize
 
 if typing.TYPE_CHECKING:
-    from typing import Sequence
+    from collections.abc import Sequence
 
     import jobflow
 

--- a/src/jobflow/schemas/job_output_schema.py
+++ b/src/jobflow/schemas/job_output_schema.py
@@ -1,6 +1,6 @@
 """A Pydantic model for Jobstore document."""
 
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 
 from monty.json import MontyDecoder
 from pydantic import BaseModel, Field, field_validator
@@ -27,7 +27,7 @@ class JobStoreDocument(BaseModel, Generic[T]):
         None,
         description="Metadeta information supplied by the user.",
     )
-    hosts: List[str] = Field(
+    hosts: list[str] = Field(
         None,
         description="The list of UUIDs of the hosts containing the job.",
     )

--- a/src/jobflow/utils/find.py
+++ b/src/jobflow/utils/find.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import typing
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Hashable
+    from collections.abc import Hashable
+    from typing import Any
 
     from monty.json import MSONable
 

--- a/tests/core/test_reference.py
+++ b/tests/core/test_reference.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Union
 
 import pytest
 
@@ -163,8 +163,8 @@ def test_schema():
         nested: InnerSchema
         nested_opt: InnerSchema = None
         nested_u: Union[InnerSchema, dict]
-        nested_l: List[InnerSchema]
-        nested_d: Dict[str, InnerSchema]
+        nested_l: list[InnerSchema]
+        nested_d: dict[str, InnerSchema]
 
     class MySchema(BaseModel):
         number: int

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -71,7 +71,7 @@ def test_settings_object(clean_dir, test_data):
         },
     }
 
-    # set the path to lood settings from
+    # set the path to load settings from
     config_file_path = str(Path.cwd() / "config.yaml")
     os.environ["JOBFLOW_CONFIG_FILE"] = config_file_path
 


### PR DESCRIPTION
We could hold off on this. Only reason for doing this is to stay in sync with `numpy` and the rest of the MP ecosystem (e.g. https://github.com/materialsproject/pymatgen/pull/3283).