### PR TITLE
JOSS Paper update: Add missing year to `refs.bib`

### DIFF
--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -103,7 +103,8 @@ year={2019}
 }
 @misc{prefect,
 title={Prefect},
-url={https://github.com/PrefectHQ/prefect}
+url={https://github.com/PrefectHQ/prefect},
+year = {2023)
 }
 @misc{redun,
 title={Redun},

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -104,7 +104,7 @@ year={2019}
 @misc{prefect,
 title={Prefect},
 url={https://github.com/PrefectHQ/prefect},
-year = {2023)
+year={2023)
 }
 @misc{redun,
 title={Redun},


### PR DESCRIPTION
The reference for Prefect was missing its year.