### PR TITLE
Replace deprecated `pkg_resources` with `importlib.metadata.version`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 exclude: "^src/atomate2/vasp/schemas/calc_types/"
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.0
     hooks:
       - id: ruff
         args: [--fix]
@@ -16,7 +16,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.0
     hooks:
       - id: black
   - repo: https://github.com/asottile/blacken-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ docs = [
     "sphinx==7.2.6",
 ]
 dev = ["pre-commit>=2.12.1"]
-tests = ["moto==4.2.5", "pytest-cov==4.1.0", "pytest==7.4.2"]
+tests = ["moto==4.2.6", "pytest-cov==4.1.0", "pytest==7.4.2"]
 vis = ["matplotlib", "pydot"]
 fireworks = ["FireWorks"]
 strict = [

--- a/src/jobflow/_version.py
+++ b/src/jobflow/_version.py
@@ -1,7 +1,7 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("jobflow").version
-except DistributionNotFound:
+    __version__ = version("jobflow")
+except PackageNotFoundError:
     # package is not installed
     __version__ = ""

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 
@@ -18,11 +20,10 @@ def uninstall_jobflow(monkeypatch):
 def test_installed_version():
     from jobflow import __version__
 
-    assert __version__ != ""
+    assert re.match(r"^\d+\.\d+\.\d+$", __version__)
 
 
-@pytest.mark.usefixtures("uninstall_jobflow")
-def test_not_installed_version(monkeypatch):
+def test_not_installed_version(uninstall_jobflow):
     import importlib
 
     from jobflow import _version


### PR DESCRIPTION
From [https://setuptools.pypa.io](https://setuptools.pypa.io/en/latest/pkg_resources.html):

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.