### PR TITLE
JOSS: Add more complete Zenodo reference info

### DIFF
--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -6,7 +6,7 @@ url = {https://github.com/materialsproject/atomate2}
 @software{quacc,
   author       = {Rosen, Andrew S},
   title        = {quacc – The Quantum Accelerator},
-  year         = 2023,
+  year         = {2023},
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.7720998},
   url          = {https://doi.org/10.5281/zenodo.7720998}
@@ -144,7 +144,7 @@ url={https://github.com/insitro/redun}
                   Singh, Divyanshu and
                   FilipBolt},
   title        = {Covalent},
-  year         = 2023,
+  year         = {2023},
   publisher    = {Zenodo},
   doi          = {10.5281/zenodo.5903364},
   url          = {https://doi.org/10.5281/zenodo.5903364}

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -8,9 +8,8 @@ url = {https://github.com/materialsproject/atomate2}
   title        = {quacc – The Quantum Accelerator},
   year         = 2023,
   publisher    = {Zenodo},
-  version      = {v0.4.0},
-  doi          = {10.5281/zenodo.10091610},
-  url          = {https://doi.org/10.5281/zenodo.10091610}
+  doi          = {10.5281/zenodo.7720998},
+  url          = {https://doi.org/10.5281/zenodo.7720998}
 }
 @article{materialsproject,
   title={Commentary: The Materials Project: A materials genome approach to accelerating materials innovation},

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -3,11 +3,14 @@ title = {Atomate2},
 year = {2023},
 url = {https://github.com/materialsproject/atomate2}
 }
-@misc{quacc,
-doi = {10.5281/zenodo.7720998},
-title = {Quacc -- The Quantum Accelerator},
-year = {2023},
-url = {https://github.com/Quantum-Accelerators/quacc}
+@software{quacc,
+  author       = {Rosen, Andrew S},
+  title        = {quacc – The Quantum Accelerator},
+  year         = 2023,
+  publisher    = {Zenodo},
+  version      = {v0.4.0},
+  doi          = {10.5281/zenodo.10091610},
+  url          = {https://doi.org/10.5281/zenodo.10091610}
 }
 @article{materialsproject,
   title={Commentary: The Materials Project: A materials genome approach to accelerating materials innovation},
@@ -112,11 +115,41 @@ title={Redun},
 year = {2023},
 url={https://github.com/insitro/redun}
 }
-@misc{covalent,
-title={Covalent},
-year = {2023},
-doi={10.5281/zenodo.5903364},
-url={https://github.com/AgnostiqHQ/covalent}
+@software{covalent,
+  author       = {Cunningham, Will
+                  Esquivel, Alejandro and
+                  Jao, Casey and
+                  Hasan, Faiyaz and
+                  Bala, Venkat and
+                  Sanand, Sankalp and
+                  Venkatesh, Prasanna and
+                  Tandon, Madhur and
+                  Emmanuel Ochia, Okechukwu and
+                  Rosen, Andrew S and
+                  dwelsch-esi and
+                  jkanem and
+                  Aravind and
+                  HaimHorowitzAgnostiq and
+                  Li, Ruihao and
+                  Neagle, Scott Wyman and
+                  valkostadinov and
+                  Ghukasyan, Ara and
+                  Rao, Poojith U and
+                  Dutta, Sayandip and
+                  WingCode and
+                  Hughes, Anna and
+                  RaviPsiog and
+                  Udayan and
+                  Akalanka and
+                  Obasi, Amara and
+                  Singh, Divyanshu and
+                  FilipBolt},
+  title        = {Covalent},
+  year         = 2023,
+  publisher    = {Zenodo},
+  version      = {v0.228.0-rc.0},
+  doi          = {10.5281/zenodo.8369670},
+  url          = {https://doi.org/10.5281/zenodo.8369670}
 }
 @misc{maggma,
 title={Maggma},

--- a/paper/refs.bib
+++ b/paper/refs.bib
@@ -146,9 +146,8 @@ url={https://github.com/insitro/redun}
   title        = {Covalent},
   year         = 2023,
   publisher    = {Zenodo},
-  version      = {v0.228.0-rc.0},
-  doi          = {10.5281/zenodo.8369670},
-  url          = {https://doi.org/10.5281/zenodo.8369670}
+  doi          = {10.5281/zenodo.5903364},
+  url          = {https://doi.org/10.5281/zenodo.5903364}
 }
 @misc{maggma,
 title={Maggma},


### PR DESCRIPTION
Addresses https://github.com/openjournals/joss-reviews/issues/5995#issuecomment-1808396589.

Namely, I previously used a minimal format for the Zenodo references. Now, I have used the one auto-generated by Zenodo. One downside of this approach is that the author list includes all contributors to the repo, no matter how large or small their contributions are.

I see two ways to go about this:

1) Just accept it and move on.

2) Keep the rest of the metadata but remove the `author` field.

@utf, any thoughts?