### PR TITLE
`run_locally()` add `root_dir: str | Path | None` keyword

### DIFF
--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -177,7 +177,11 @@ class OutputReference(MSONable):
 
         for attr_type, attr in self.attributes:
             # i means index else use attribute access
-            data = data[attr] if attr_type == "i" else getattr(data, attr)
+            data = (
+                data[attr]
+                if attr_type == "i" or isinstance(data, dict)
+                else getattr(data, attr)
+            )
 
         return data
 

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -62,6 +62,14 @@ def test_simple_flow(memory_jobstore, clean_dir, simple_flow, capsys):
     folders = list(Path(".").glob("job_*/"))
     assert len(folders) == 1
 
+    # run with folders and root_dir
+    responses = run_locally(
+        flow, store=memory_jobstore, create_folders=True, root_dir="test"
+    )
+    assert responses[uuid][1].output == "12345_end"
+    folders = list(Path("test").glob("job_*/"))
+    assert len(folders) == 1
+
 
 def test_connected_flow(memory_jobstore, clean_dir, connected_flow):
     from jobflow import run_locally

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -63,11 +63,12 @@ def test_simple_flow(memory_jobstore, clean_dir, simple_flow, capsys):
     assert len(folders) == 1
 
     # run with folders and root_dir
+    assert Path(root_dir := "test").exists() is False
     responses = run_locally(
-        flow, store=memory_jobstore, create_folders=True, root_dir="test"
+        flow, store=memory_jobstore, create_folders=True, root_dir=root_dir
     )
     assert responses[uuid][1].output == "12345_end"
-    folders = list(Path("test").glob("job_*/"))
+    folders = list(Path(root_dir).glob("job_*/"))
     assert len(folders) == 1
 
 


### PR DESCRIPTION
So users don't have to change directory to control where flows run.

Added a test and docs.