### PR TITLE
fix Flow deserialization for hosts

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -794,7 +794,8 @@ class Flow(MSONable):
                     f"current Flow ({self.uuid})"
                 )
             job_ids.add(job.uuid)
-            job.add_hosts_uuids(hosts)
+            if job.host != self.uuid:
+                job.add_hosts_uuids(hosts)
         self._jobs += tuple(jobs)
 
     def remove_jobs(self, indices: int | list[int]):

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -497,6 +497,7 @@ def test_serialization():
     decoded_flow = MontyDecoder().process_decoded(encoded_flow)
 
     assert decoded_flow[0].host == host_uuid
+    assert flow_host.jobs[0].hosts == decoded_flow.jobs[0].hosts
 
 
 def test_update_kwargs():


### PR DESCRIPTION
## Summary

There was an issue with the (de)serialization of a Flow. Since the hosts are added when a Flow is created from a list of Flows/Jobs, during deserialization hosts were duplicated for each of the jobs contained in the Flow.

This PR should fix this.