### PR TITLE
Fix tutorial link formatting in docs

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -14,4 +14,4 @@ Tutorials
    tutorials/8-fireworks
 
 .. Note::
-    [@jageo](https://github.com/JaGeo) also has a set of [Jobflow tutorials](https://jageo.github.io/Advanced_Jobflow_Tutorial/intro.html) written within the context of computational materials science applications, which you may wish to check out after exploring the basics here.
+    `@jageo <https://github.com/JaGeo>`_ also has a set of `Jobflow tutorials <https://jageo.github.io/Advanced_Jobflow_Tutorial/intro.html>`_ written within the context of computational materials science applications, which you may wish to check out after exploring the basics here.


### PR DESCRIPTION
Closes #501.

Couldn't find any other broken rst/md links.