### PR TITLE
Fix handling of function from standard library

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -554,7 +554,6 @@ class Job(MSONable):
         --------
         Response, .OutputReference
         """
-        import builtins
         import types
         from datetime import datetime
 
@@ -578,7 +577,7 @@ class Job(MSONable):
         # if function is bound method we need to do some magic to bind the unwrapped
         # function to the class/instance
         bound = getattr(self.function, "__self__", None)
-        if bound is not None and bound is not builtins:
+        if bound is not None and not isinstance(bound, types.ModuleType):
             function = types.MethodType(function, bound)
 
         response = function(*self.function_args, **self.function_kwargs)

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -123,6 +123,13 @@ def test_job_run(capsys, memory_jobstore, memory_data_jobstore):
     with pytest.raises(RuntimeError):
         test_job.run(memory_jobstore)
 
+    # test on standard library functions
+    import time
+
+    test_job = Job(time.sleep, function_args=(0.001,))
+    response = test_job.run(memory_jobstore)
+    assert isinstance(response, Response)
+
 
 def test_replace_response(memory_jobstore):
     from jobflow import Flow, Job, Response


### PR DESCRIPTION
## Summary

I was trying to use a function from the standard library to create a simple example and I got an error:

```python
import time
from jobflow import Job, SETTINGS

j = Job(time.sleep, (1,))
j.run(SETTINGS.JOB_STORE)
```

gives

> TypeError: time.sleep() takes exactly one argument (2 given)

The reason is that `sleep` has a `__self__` attribute and in `Job` it is then converted to a bound method. This seems to be shared by most (all?) the functions in the standard library. 

To adress this I changed the check performed in `Job.run()` assuming that if the `__self__` is a module, than the callable should not be converted to a method. I am not entirely sure if I may be missing some case where this is not true.