### PR TITLE
Optional Flag to help Debugging

### DIFF
--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -102,14 +102,19 @@ def run_locally(
             errored.add(job.uuid)
             return None, False
 
-        try:
+        if SETTINGS.RAISE_IMMEDIATELY:
             response = job.run(store=store)
-        except Exception:
-            import traceback
+        else:
+            try:
+                response = job.run(store=store)
+            except Exception:
+                import traceback
 
-            logger.info(f"{job.name} failed with exception:\n{traceback.format_exc()}")
-            errored.add(job.uuid)
-            return None, False
+                logger.info(
+                    f"{job.name} failed with exception:\n{traceback.format_exc()}"
+                )
+                errored.add(job.uuid)
+                return None, False
 
         responses[job.uuid][job.index] = response
 

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -21,6 +21,7 @@ def run_locally(
     root_dir: str | Path | None = None,
     ensure_success: bool = False,
     allow_external_references: bool = False,
+    raise_immediately: bool = False,
 ) -> dict[str, dict[int, jobflow.Response]]:
     """
     Run a :obj:`Job` or :obj:`Flow` locally.
@@ -46,6 +47,10 @@ def run_locally(
     allow_external_references : bool
         If False all the references to other outputs should be from other Jobs
         of the Flow.
+    raise_immediately : bool
+        If True, raise an exception immediately if a job fails. If False, continue
+        running the flow and only raise an exception at the end if the flow did not
+        finish running successfully.
 
     Returns
     -------
@@ -102,7 +107,7 @@ def run_locally(
             errored.add(job.uuid)
             return None, False
 
-        if SETTINGS.RAISE_IMMEDIATELY:
+        if raise_immediately:
             response = job.run(store=store)
         else:
             try:

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -117,12 +117,6 @@ class JobflowSettings(BaseSettings):
         "%Y-%m-%d-%H-%M-%S-%f",
         description="Date stamp format used to create directories",
     )
-    RAISE_IMMEDIATELY: bool = Field(
-        default=False,
-        description="Whether to raise an error immediately when the job fails. "
-        "Usually we allow jobs to fail and check the status post mortem."
-        "Sometimes, debugging is easier if the error is raised immediately.",
-    )
     model_config = SettingsConfigDict(env_prefix="jobflow_")
 
     @model_validator(mode="before")

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -117,6 +117,12 @@ class JobflowSettings(BaseSettings):
         "%Y-%m-%d-%H-%M-%S-%f",
         description="Date stamp format used to create directories",
     )
+    RAISE_IMMEDIATELY: bool = Field(
+        default=False,
+        description="Whether to raise an error immediately when the job fails. "
+        "Usually we allow jobs to fail and check the status post mortem."
+        "Sometimes, debugging is easier if the error is raised immediately.",
+    )
     model_config = SettingsConfigDict(env_prefix="jobflow_")
 
     @model_validator(mode="before")

--- a/tests/managers/test_local.py
+++ b/tests/managers/test_local.py
@@ -331,6 +331,9 @@ def test_error_flow(memory_jobstore, clean_dir, error_flow, capsys):
     with pytest.raises(RuntimeError):
         run_locally(flow, store=memory_jobstore, ensure_success=True)
 
+    with pytest.raises(ValueError, match="errored"):
+        run_locally(flow, store=memory_jobstore, raise_immediately=True)
+
 
 def test_ensure_success_with_replace(memory_jobstore, error_replace_flow, capsys):
     from jobflow import run_locally


### PR DESCRIPTION
## Optional Flag to help Debugging

Currently, whenever any `run_locally` call fails.
The stack trace is produced at the end and we only have access to the error via a logger even

if you set `RAISE_IMMEDIATELY: true`, the stack trace will be provided where the excution actually failed.
This allows you to move around better within a debugger.
