### PR TITLE
CounterStore

### DIFF
--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -901,5 +901,5 @@ def _get_counter_store_from_docs_store(docs_store: Store, coll_name: str):
             "To create a counter store, the docs store must be a MongoStore."
         )
     store_dict_ = docs_store.as_dict()
-    store_dict_["collection_name"] = store_dict_["collection_name"] + coll_name
+    store_dict_["collection_name"] = coll_name
     return docs_store.__class__.from_dict(store_dict_)

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -4,16 +4,12 @@ from __future__ import annotations
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from maggma.stores import MemoryStore
+from maggma.stores import MemoryStore, Store
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from jobflow import JobStore
-
-if TYPE_CHECKING:
-    from maggma.stores import Store
 
 DEFAULT_CONFIG_FILE_PATH = Path("~/.jobflow.yaml").expanduser().as_posix()
 

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -5,7 +5,7 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 
-from maggma.stores import MemoryStore, Store
+from maggma.stores import MemoryStore
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -113,12 +113,6 @@ class JobflowSettings(BaseSettings):
         description="Default JobStore to use when running locally or using FireWorks. "
         "See the :obj:`JobflowSettings` docstring for more details on the "
         "accepted formats.",
-    )
-    COUNTER_STORE: Store | str | None = Field(
-        None,
-        description="Store to keep track of counters. "
-        "Jobflow does not explicitly use this. However, some workflows may benefit "
-        "from incrementing global counters.",
     )
     DIRECTORY_FORMAT: str = Field(
         "%Y-%m-%d-%H-%M-%S-%f",

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -4,6 +4,7 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 
+from maggma.core import Store
 from maggma.stores import MemoryStore
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -112,6 +113,12 @@ class JobflowSettings(BaseSettings):
         description="Default JobStore to use when running locally or using FireWorks. "
         "See the :obj:`JobflowSettings` docstring for more details on the "
         "accepted formats.",
+    )
+    COUNTER_STORE: Store = Field(
+        None,
+        description="Store to keep track of counters. "
+        "Jobflow does not explicitly use this. However, some workflows may benefit "
+        "from incrementing global counters.",
     )
     DIRECTORY_FORMAT: str = Field(
         "%Y-%m-%d-%H-%M-%S-%f",

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,15 +1,19 @@
 """Settings for jobflow."""
+from __future__ import annotations
 
 import warnings
 from collections import defaultdict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from maggma.core import Store
 from maggma.stores import MemoryStore
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from jobflow import JobStore
+
+if TYPE_CHECKING:
+    from maggma.stores import Store
 
 DEFAULT_CONFIG_FILE_PATH = Path("~/.jobflow.yaml").expanduser().as_posix()
 
@@ -114,7 +118,7 @@ class JobflowSettings(BaseSettings):
         "See the :obj:`JobflowSettings` docstring for more details on the "
         "accepted formats.",
     )
-    COUNTER_STORE: Store = Field(
+    COUNTER_STORE: Store | str | None = Field(
         None,
         description="Store to keep track of counters. "
         "Jobflow does not explicitly use this. However, some workflows may benefit "

--- a/src/jobflow/settings.py
+++ b/src/jobflow/settings.py
@@ -1,5 +1,4 @@
 """Settings for jobflow."""
-from __future__ import annotations
 
 import warnings
 from collections import defaultdict

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -483,3 +483,27 @@ def test_from_dict_spec():
 def test_ensure_index(memory_jobstore):
     assert memory_jobstore.ensure_index("test_key")
     # TODO: How to check for exception?
+
+
+def test_counter_store():
+    from maggma.stores import MemoryStore
+
+    from jobflow import JobStore
+
+    store1 = JobStore(MemoryStore(), counter_store=MemoryStore())
+    store1.connect()
+    store1.reset_counter("c1")
+    assert store1.get_counter("c1") == 0
+    store1.increment_counter("c1")
+    store1.increment_counter("c1")
+    store1.increment_counter("c1")
+    assert store1.get_counter("c1") == 3
+    store1.reset_counter("c1")
+    assert store1.get_counter("c1") == 0
+
+    with pytest.raises(ValueError, match="Counter c2 not found in store"):
+        store1.get_counter("c2")
+
+    store2 = JobStore(MemoryStore(), counter_store="test1")
+    store2.connect()
+    store2.reset_counter("c1")

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -501,9 +501,16 @@ def test_counter_store():
     store1.reset_counter("c1")
     assert store1.get_counter("c1") == 0
 
-    with pytest.raises(ValueError, match="Counter c2 not found in store"):
+    with pytest.raises(ValueError, match="Counter with key c2 does not exist."):
         store1.get_counter("c2")
 
     store2 = JobStore(MemoryStore(), counter_store="test1")
     store2.connect()
     store2.reset_counter("c1")
+    assert store2.get_counter("c1") == 0
+    assert store2.counter_store.collection_name == "test1"
+
+    store3 = JobStore(MemoryStore(), counter_store=None)
+    store3.connect()
+    with pytest.raises(ValueError, match="No counter store has been set."):
+        store3.reset_counter("c1")


### PR DESCRIPTION
## Generical global counters might be useful for some special workflows

Many of the document models in emmet are designed to deal with either `int` or `"mp-"+int` type of ids for the different documents.  As such, they sometimes require unique integer counters for specific downstream documents to be built properly.
This feature should allow atomate2 to automatically assign unique ids to the tasks which (I believe) is currently unset.
If the task id is set I think more of the aggregated document model in emmet can be directly used in the middle of future more complex workflows.

An example of this problem is here:
https://github.com/materialsproject/atomate2/pull/655

Where the `InsertionElectrode` document expects task_id to be set.
