### PR TITLE
jsanitize fireworks Task

### DIFF
--- a/src/jobflow/managers/fireworks.py
+++ b/src/jobflow/managers/fireworks.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import typing
 
 from fireworks import FiretaskBase, Firework, FWAction, Workflow, explicit_serialize
+from fireworks.utilities.fw_serializers import recursive_serialize, serialize_fw
+from monty.json import jsanitize
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -197,3 +199,16 @@ class JobFiretask(FiretaskBase):
             defuse_workflow=response.stop_jobflow,
             defuse_children=response.stop_children,
         )
+
+    @serialize_fw
+    @recursive_serialize
+    def to_dict(self) -> dict:
+        """
+        Serialize version of the FireTask.
+
+        Overrides the original method to explicitly jsanitize the Job
+        to handle cases not properly handled by fireworks, like a Callable.
+        """
+        d = dict(self)
+        d["job"] = jsanitize(d["job"].as_dict())
+        return d

--- a/tests/managers/conftest.py
+++ b/tests/managers/conftest.py
@@ -399,3 +399,25 @@ def replace_and_detour_flow(replace_and_detour_job, simple_job):
         return Flow([replace, simple], simple.output, order=JobOrder.LINEAR)
 
     return _gen
+
+
+@pytest.fixture(scope="session")
+def maker_with_callable():
+    from dataclasses import dataclass
+    from typing import Callable
+
+    from jobflow.core.job import job
+    from jobflow.core.maker import Maker
+
+    global TestCallableMaker
+
+    @dataclass
+    class TestCallableMaker(Maker):
+        f: Callable
+        name: str = "TestCallableMaker"
+
+        @job
+        def make(self, a, b):
+            return self.f([a, b])
+
+    return TestCallableMaker


### PR DESCRIPTION
I have seen that in some cases the `JobFiretask` does not properly serialize a Job.
Consider the case of a Maker with a Callable as an attribute.

```python
from fireworks import LaunchPad
from jobflow.managers.fireworks import job_to_firework

from dataclasses import dataclass
from typing import Callable
from jobflow import Maker, job


def print_function():
    print("TEST")


@dataclass
class CallableMaker(Maker):
    f: Callable
    name: str = "CallableMaker"

    @job
    def make(self, *args, **kwargs):
        self.f()

j = CallableMaker(f=print_function).make()

fw = job_to_firework(j)
lpad = LaunchPad.auto_load()
lpad.add_wf(fw)
```

When running this, in the firework DB you have
```json
{
    "spec": {
        "_tasks": [
            {
                "job": {
                    "@module": "jobflow.core.job",
                    "@class": "Job",
                    "@version": "0.1.14.post122+g6439853",
                    "function": {
                        "@module": "__main__",
                        "@callable": "CallableMaker.make",
                        "@bound": {
                            "@module": "__main__",
                            "@class": "CallableMaker",
                            "@version": null,
                            "f": "<function print_function at 0x16ad82cb0>",
                            "name": "CallableMaker"
                        }
                    },
                   ...

}
```
Where the function is serialized as a string.

This PR addresses this issue by overriding the `JobFiretask.to_dict` method and explicitly jsanitizing the Job.