### PR TITLE
Fix jsanitize in `contains_flow_or_job`

### DIFF
--- a/src/jobflow/utils/find.py
+++ b/src/jobflow/utils/find.py
@@ -205,7 +205,7 @@ def contains_flow_or_job(obj: Any) -> bool:
         # argument is a primitive, we won't find an flow or job here
         return False
 
-    obj = jsanitize(obj, strict=True, allow_bson=True)
+    obj = jsanitize(obj, strict=True, allow_bson=True, enum_values=True)
 
     # recursively find any reference classes
     locations = find_key_value(obj, "@class", "Flow")


### PR DESCRIPTION
This change in emmet https://github.com/materialsproject/emmet/commit/7735bb1a51cd9b339789bbdca0df92fbe366ddb8 leads to an error in `contains_flow_or_job`, due to the impossibility to call as_dict on some Enums. 
This PR adds the `enum_values=True` to handle those cases. 

In general, I am wondering if it is worth making this check every time a Flow is instantiated.