### PR TITLE
fix @job annotation (again)

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -78,7 +78,9 @@ def job(method: Callable = None, **job_kwargs) -> Callable[..., Callable[..., Jo
     pass
 
 
-def job(method: Callable = None, **job_kwargs):
+def job(
+    method: Callable = None, **job_kwargs
+) -> Callable[..., Job] | Callable[..., Callable[..., Job]]:
     """
     Wrap a function to produce a :obj:`Job`.
 


### PR DESCRIPTION
This is a follow-up of #578 . As it turns out, `pycharm` only reacts on the `@overload` if the original function is also annotated. This is also in agreement with `mypy`.