### PR TITLE
Store files as output

### DIFF
--- a/src/jobflow/core/file_store.py
+++ b/src/jobflow/core/file_store.py
@@ -1,0 +1,245 @@
+"""A basic implementation of a FileStore."""
+
+from __future__ import annotations
+
+import shutil
+from abc import ABCMeta, abstractmethod, abstractproperty
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from monty.json import MSONable
+
+if TYPE_CHECKING:
+    import io
+
+    from maggma.stores.ssh_tunnel import SSHTunnel
+
+
+class FileStore(MSONable, metaclass=ABCMeta):
+    """Abstract class for a file store."""
+
+    @abstractproperty
+    def name(self) -> str:
+        """Return a string representing this data source."""
+
+    @abstractmethod
+    def put(self, src: str | io.IOBase, dest: str) -> str:
+        """
+        Insert a file in the Store.
+
+        Return the string reference that can be used to access
+        the file again.
+        """
+
+    @abstractmethod
+    def get(self, reference: str, dest: str | io.IOBase):
+        """Fetch a file from the store using the reference."""
+
+    @abstractmethod
+    def remove(self, reference: str):
+        """Remove a file from the store."""
+
+    @abstractmethod
+    def connect(self, force_reset: bool = False):
+        """
+        Connect to the source data.
+
+        Args:
+            force_reset: whether to reset the connection or not
+        """
+
+    @abstractmethod
+    def close(self):
+        """Close any connections."""
+
+
+class FileSystemFileStore(FileStore):
+    """File store on the file system."""
+
+    def __init__(self, path: str):
+        self.path = Path(path)
+
+    @property
+    def name(self) -> str:
+        """Return a string representing this data source."""
+        return f"fs:{self.path}"
+
+    def put(self, src: str | io.IOBase, dest: str) -> str:
+        """
+        Insert a file in the Store.
+
+        Return the string reference that can be used to access
+        the file again.
+        """
+        path_dest = self.path / dest
+
+        path_dest.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(src, str):
+            shutil.copy2(src, path_dest)
+        else:
+            with open(path_dest, "wb") as f:
+                f.write(src.read())
+
+        return dest
+
+    def get(self, reference: str, dest: str | io.IOBase):
+        """Fetch a file from the store using the reference."""
+        if isinstance(dest, str):
+            shutil.copy2(self.path / reference, dest)
+        else:
+            with open(self.path / reference, "rb") as f:
+                dest.write(f.read())
+
+    def remove(self, reference: str):
+        """Remove a file from the store."""
+        file_path = self.path / reference
+        file_path.unlink(missing_ok=True)
+
+    def connect(self, force_reset: bool = False):
+        """
+        Connect to the source data.
+
+        Args:
+            force_reset: whether to reset the connection or not
+        """
+        self.path.mkdir(exist_ok=True)
+
+    def close(self):
+        """Close any connections."""
+
+
+class GridFSFileStore(FileStore):
+    """GridFS store for files."""
+
+    def __init__(
+        self,
+        database: str,
+        collection_name: str,
+        host: str = "localhost",
+        port: int = 27017,
+        username: str = "",
+        password: str = "",
+        compression: bool = False,
+        ensure_metadata: bool = False,
+        searchable_fields: list[str] | None = None,
+        auth_source: str | None = None,
+        mongoclient_kwargs: dict | None = None,
+        ssh_tunnel: SSHTunnel | None = None,
+        **kwargs,
+    ):
+        """
+        Initialize a GridFS Store for binary data.
+
+        Args:
+            database: database name
+            collection_name: The name of the collection.
+                This is the string portion before the GridFS extensions
+            host: hostname for the database
+            port: port to connect to
+            username: username to connect as
+            password: password to authenticate as
+            compression: compress the data as it goes into GridFS
+            auth_source: The database to authenticate on. Defaults to the database name.
+            ssh_tunnel: An SSHTunnel object to use.
+        """
+        self.database = database
+        self.collection_name = collection_name
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self._coll: Any = None
+        self.compression = compression
+        self.ssh_tunnel = ssh_tunnel
+
+        if auth_source is None:
+            auth_source = self.database
+        self.auth_source = auth_source
+        self.mongoclient_kwargs = mongoclient_kwargs or {}
+
+    @property
+    def name(self) -> str:
+        """Return a string representing this data source."""
+        return f"gridfs://{self.host}/{self.database}/{self.collection_name}"
+
+    def connect(self, force_reset: bool = False):
+        """
+        Connect to the source data.
+
+        Args:
+            force_reset: whether to reset the connection or not when the Store is
+                already connected.
+        """
+        import gridfs
+        from pymongo import MongoClient
+
+        if not self._coll or force_reset:
+            if self.ssh_tunnel is None:
+                host = self.host
+                port = self.port
+            else:
+                self.ssh_tunnel.start()
+                host, port = self.ssh_tunnel.local_address
+
+            conn: MongoClient = (
+                MongoClient(
+                    host=host,
+                    port=port,
+                    username=self.username,
+                    password=self.password,
+                    authSource=self.auth_source,
+                    **self.mongoclient_kwargs,
+                )
+                if self.username != ""
+                else MongoClient(host, port, **self.mongoclient_kwargs)
+            )
+            db = conn[self.database]
+            self._coll = gridfs.GridFS(db, self.collection_name)
+
+    @property
+    def _collection(self):
+        """Property referring to underlying pymongo collection."""
+        if self._coll is None:
+            raise RuntimeError(
+                "Must connect Mongo-like store before attempting to use it"
+            )
+        return self._coll
+
+    def close(self):
+        """Close any connections."""
+        self._coll = None
+        if self.ssh_tunnel is not None:
+            self.ssh_tunnel.stop()
+
+    def put(self, src: str | io.IOBase, dest: str) -> str:
+        """
+        Insert a file in the Store.
+
+        Return the string reference that can be used to access
+        the file again.
+        """
+        metadata = {"path": dest}
+        if isinstance(src, str):
+            with open(src, "rb") as f:
+                oid = self._collection.put(f, metadata=metadata)
+        else:
+            oid = self._collection.put(src, metadata=metadata)
+
+        return str(oid)
+
+    def get(self, reference: str, dest: str | io.IOBase):
+        """Fetch a file from the store using the reference."""
+        from bson import ObjectId
+
+        data = self._collection.find_one({"_id": ObjectId(reference)})
+        if isinstance(dest, str):
+            with open(dest, "wb") as f:
+                f.write(data.read())
+        else:
+            dest.write(dest.read())
+
+    def remove(self, reference: str):
+        """Remove a file from the store."""
+        from bson import ObjectId
+
+        self._collection.delete({"_id": ObjectId(reference)})

--- a/src/jobflow/core/schemas.py
+++ b/src/jobflow/core/schemas.py
@@ -50,6 +50,6 @@ class JobStoreDocument(BaseModel):
         None,
         description="The name of the job.",
     )
-    files: list[FileData] = Field(
+    files: list[FileData] | None = Field(
         None, description="List of files stored as output of the Job in a FileStore."
     )

--- a/src/jobflow/core/schemas.py
+++ b/src/jobflow/core/schemas.py
@@ -1,8 +1,26 @@
 """A Pydantic model for Jobstore document."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+
+class FileData(BaseModel):
+    """A Pydantic mode for files data in a JobStoreDocument."""
+
+    name: str = Field(description="The name of the file that has been uploaded.")
+    reference: str = Field(
+        description="A unique reference used to refer the file in the FileStore."
+    )
+    store: str = Field(
+        description="Name of the FileStore when the file has been stored."
+    )
+    metadata: dict[str, Any] | None = Field(
+        None, description="A generic dictionary with metadata identifying the file."
+    )
+    path: str = Field(description="The relative path of the file that was stored.")
 
 
 class JobStoreDocument(BaseModel):
@@ -31,4 +49,7 @@ class JobStoreDocument(BaseModel):
     name: str = Field(
         None,
         description="The name of the job.",
+    )
+    files: list[FileData] = Field(
+        None, description="List of files stored as output of the Job in a FileStore."
     )

--- a/src/jobflow/utils/uid.py
+++ b/src/jobflow/utils/uid.py
@@ -113,3 +113,28 @@ def _get_id_type(uid: str) -> str:
         pass
 
     raise ValueError(f"ID type for {uid} not recognized.")
+
+
+def uid_to_path(
+    uid: str, index: int | None = None, num_subdirs: int = 3, subdir_len: int = 2
+):
+    """Generate a path from a unique id."""
+    import os
+
+    # TODO adapt this for ULID if needed
+    u = UUID(uid)
+    u_hex = u.hex
+
+    # Split the digest into groups of "subdir_len" characters
+    subdirs = [
+        u_hex[i : i + subdir_len]
+        for i in range(0, num_subdirs * subdir_len, subdir_len)
+    ]
+
+    # add the index to the final dir name
+    dir_name = f"{uid}"
+    if index is not None:
+        dir_name += f"_{index}"
+
+    # Combine root directory and subdirectories to form the final path
+    return os.path.join(*subdirs, dir_name)


### PR DESCRIPTION
The proposal of allowing to store files directly as output of jobflow has been raised several times. For example in this discussion: https://github.com/materialsproject/atomate2/issues/515. 
The idea is that, while it would be in principle possible to store a file using a maggma Store (e.g. a GridFSStore or an S3Store), this requires respecting the Store API. This would definitely have limitations, for example the need to load in memory the whole file.

This is an initial draft where jobs are allowed to store files directly in a new kind of store. In any case there are definitely several points that should be considered carefully and room for improvement. I consider this the basis to start a discussion.

Based on previous interactions and discussions on the topic I suppose that @utf, @rkingsbury, @ml-evs, @computron may be interested.

## Changes

The current implementation introduces the following changes

* A new type of store `FileStore`, different from the one in maggma. This exposes methods to directly interact with the files (`put`, `get`). A couple actual stores are implemented, one based on the file system and one on gridfs. Those are here for testing purposes, but if the concept is acceptable these can be moved to maggma (or some other package?).
* The JobStore has a new attribute `files_stores` mimicking the `additional_stores` to define the stores where the files wiil be saved.
* The `Response` has an additional attibute `output_files`. This is a dictionary where the key is the name of the store where the files should be saved. The value is a string or a list of strings with relative paths to the files that should be uploaded. This could be extended to be a dictionary to handle more cases (e.g. store all the produced files, or decide what to do if a file is missing).
* The `JobStoreDocument` has an additional attribute `files`, that contain a list of `FileData`. This contains the name of the store and the reference to retrieve the file, along with the name and path of the file.
* The `Job.run` method, after the Job is completed, checks if the Response contains the `output_files` and stores the files before storing the `JobStoreDocument`. The `files` attribute of the `JobStoreDocument` is filled in using the reference to the stored files and this is then added to the JobStore.

All these changes should be backward-compatible with existing jobflow workflows.

## Example

Here is a simple example to demonstrate the concept. The configuration, including the new JobStore:
```yaml
JOB_STORE: 
  docs_store:
    type: MongoStore
    collection_name: jobflow 
    database: jobflow_test
    host: localhost
    password: ''
    port: 27017
  additional_stores:
    data:
      type: GridFSStore
      database: jobflow_test
      host: localhost
      port: 27017
      password: ""
      collection_name: outputs_blobs
  files_stores:
    data_files:
      type: FileSystemFileStore
      path: /some/path/fs_file_store
    data_files_gfs:
      type: GridFSFileStore
      database: jobflow_test
      host: localhost
      port: 27017
      password: ""
      collection_name: outputs_files
  load: false
  save: {}
```

A Job that creates some files and stores them in the output:

```python
from jobflow import job, Response, Flow, run_locally


@job
def add(a, b):
    with open("output_file", "wt") as f:
        f.write(f"The result is {a + b}")
    return Response(a + b, output_files={"data_files_gfs": "output_file"})


add_first = add(1, 5)
add_second = add(add_first.output, 3)

flow = Flow([add_first, add_second])

run_locally(flow, create_folders=True)
```

A script to retrieve the file after completion: 

```python
from jobflow import SETTINGS
from jobflow.core.schemas import JobStoreDocument

js = SETTINGS.JOB_STORE

js.connect()
js_doc = JobStoreDocument.model_validate(js.query_one())

print(js_doc.files[0])
js.get_file(dest="downloaded_file", reference="output_file", job_doc=js_doc)
```

## Discussion

Considering this as a good starting point, I think there are several points that may be worth discussing. I will list some here.

* The API of the `FileStore`. Is it enough a minimal API like the one drafted here? Or should it be more involved?
* While the use of the additional_stores is driven by the arguments of the `@job` decorator, here I am proposing to use `Response` to decide which files to save. This is to avoid clashes with the `kwargs` arguments of the `additional_stores` and to allow a finer control for the Job about which files to store, but other solutions could be found to define elsewhere the files to be stored.
* Is the root of the `JobStoreDocument` the best place for the file information? Or should it be in the `output`? (I think that adding it to the `output` part will complicate how to decide which files should actually be copied, but maybe someone has a good idea of how to handle that).
* What should happen to the files if the document is modified? At the moment, if I am not wrong, also the blobs in the `additional_stores` are not cleaned if the main JobStoreDocument is updated. In this context the same would be for the files stored. Deciding if and how to update the files in the store may be tricky.
* Which information about the file should be present in the `JobStoreDocument` (here in the `FileData`). Are there more information that should be stored?
* I did not implement a way to use the files in subsequent jobs, like is possible with the output references. It could be possible to do something using `job.output_files`  as a reference and specify that you want the file to be copied before the job starts. However, it is not clear to me what would be the typical use case for this functionality and how to control where the file should be copied exactly (e.g. filename, subfolders).