### PR TITLE
Add support for `pip install jobflow[remote]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ulid = ["python-ulid"]
+remote = ["jobflow-remote"]
 docs = [
     "autodoc_pydantic==2.1.0",
     "furo==2024.5.6",


### PR DESCRIPTION
I updated `pyproject.toml` to support doing `pip install jobflow[remote]` to install both `jobflow` and `jobflow-remote`. In principle, this will also allow `jobflow` to have some flexibility with setting version pins (if needed) on `jobflow-remote`.
