### PR TITLE
fix @job annotation again (again)

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -69,17 +69,22 @@ class JobConfig(MSONable):
 
 
 @overload
-def job(method: Callable = None) -> Callable[..., Job]:
+def job(method: Callable | None = None) -> Callable[..., Job]:
     pass
 
 
 @overload
-def job(method: Callable = None, **job_kwargs) -> Callable[..., Callable[..., Job]]:
+def job(method: Callable, **job_kwargs) -> Callable[..., Job]:
+    pass
+
+
+@overload
+def job(method: None = None, **job_kwargs) -> Callable[..., Callable[..., Job]]:
     pass
 
 
 def job(
-    method: Callable = None, **job_kwargs
+    method: Callable | None = None, **job_kwargs
 ) -> Callable[..., Job] | Callable[..., Callable[..., Job]]:
     """
     Wrap a function to produce a :obj:`Job`.


### PR DESCRIPTION
Serves as a follow-up for #578 . I recognized that there is another use case, which is for example used in here: https://github.com/materialsproject/atomate2/blob/e210b58b93d33b13af800dd001c9689f96a6eb0c/src/atomate2/vasp/jobs/base.py#L150

This requires another overload block. Here is the quick example extended:

```
from jobflow import job

def add(a: int, b: int) -> int:
    """Add function."""
    return a + b

@job
def add_job(a: int, b: int) -> int:
    """Add job."""
    return a + b

@job(large_data="data", graphs="graph")
def compute(a: int, b: int) -> dict[str, int]:
    """Compute job."""
    return {"data": b, "graph": a}

@job(method=None, large_data="data", graphs="graph")
def compute2(a: int, b: int) -> dict[str, int]:
    """Compute job with explicit None method."""
    return {"data": b, "graph": a}

def job_wrapper(method: Callable[..., Any]) -> Callable[..., Job]:
    """Job wrapper."""
    return job(method, data="data")

@job_wrapper
def wrapped_add_job(a: int, b: int) -> int:
    """Add job wrapped."""
    return a + b


reveal_type(add(1, 2))
reveal_type(add_job(1, 2))
reveal_type(compute(1, 2))
reveal_type(compute2(1, 2))
reveal_type(wrapped_add_job(1, 2))
```

Running mypy over this using old master branch:

```
error: No overload variant of "job" matches argument types "None", "str", "str"  [call-overload]
error: Incompatible return value type (got "Callable[..., Callable[..., Job]]", expected "Callable[..., Job]")  [return-value]
Revealed type is "builtins.int"
Revealed type is "jobflow.core.job.Job"
Revealed type is "jobflow.core.job.Job"
Revealed type is "Any"
Revealed type is "jobflow.core.job.Job"
```

And now with the new version:

```
Revealed type is "builtins.int"
Revealed type is "jobflow.core.job.Job"
Revealed type is "jobflow.core.job.Job"
Revealed type is "jobflow.core.job.Job"
Revealed type is "jobflow.core.job.Job"
```