### PR TITLE
Add `Flow.metadata` attribute and `Flow.update_metadata` method

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -659,13 +659,13 @@ class Flow(MSONable):
         """
         from jobflow.utils.dict_mods import apply_mod
 
-        if target in ["flow", "both"] and name_filter in (None, self.name):
+        if target in ("flow", "both") and name_filter in (None, self.name):
             if dict_mod:
                 apply_mod(update, self.metadata)
             else:
                 self.metadata.update(update)
 
-        if target in ["jobs", "both"]:
+        if target in ("jobs", "both"):
             for job in self:
                 job.update_metadata(
                     update,
@@ -675,7 +675,7 @@ class Flow(MSONable):
                     dynamic=dynamic,
                 )
 
-        if dynamic and target in ["jobs", "both"]:
+        if dynamic and target in ("jobs", "both"):
             dict_input = {
                 "update": update,
                 "name_filter": name_filter,

--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -67,6 +67,11 @@ class Flow(MSONable):
         automatically when a flow is included in the jobs array of another flow.
         The object identified by one UUID of the list should be contained in objects
         identified by its subsequent elements.
+    metadata
+        A dictionary of information that will get stored in the Flow collection.
+    metadata_updates
+        A list of updates for the metadata that will be applied to any dynamically
+        generated sub Flow/Job.
 
     Raises
     ------

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -343,7 +343,6 @@ class Job(MSONable):
         function_args = () if function_args is None else function_args
         function_kwargs = {} if function_kwargs is None else function_kwargs
         uuid = suid() if uuid is None else uuid
-        metadata = {} if metadata is None else metadata
         config = JobConfig() if config is None else config
 
         # make a deep copy of the function (means makers do not share the same instance)
@@ -354,7 +353,7 @@ class Job(MSONable):
         self.uuid = uuid
         self.index = index
         self.name = name
-        self.metadata = metadata
+        self.metadata = metadata or {}
         self.config = config
         self.hosts = hosts or []
         self.metadata_updates = metadata_updates or []

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -926,6 +926,7 @@ class Job(MSONable):
         function_filter: Callable = None,
         dict_mod: bool = False,
         dynamic: bool = True,
+        callback_filter: Callable[[jobflow.Flow | Job], bool] = lambda _: True,
     ):
         """
         Update the metadata of the job.
@@ -949,6 +950,9 @@ class Job(MSONable):
         dynamic
             The updates will be propagated to Jobs/Flows dynamically generated at
             runtime.
+        callback_filter
+            A function that takes a Flow or Job instance and returns True if updates
+            should be applied to that instance. Allows for custom filtering logic.
 
         Examples
         --------
@@ -967,11 +971,16 @@ class Job(MSONable):
         will not only set the `example` metadata to the `test_job`, but also to all the
         new Jobs that will be generated at runtime by the ExampleMaker.
 
-        `update_metadata` can be called multiple times with different `name_filter` or
-        `function_filter` to control which Jobs will be updated.
+        `update_metadata` can be called multiple times with different filters to control
+        which Jobs will be updated. For example, using a callback filter:
 
-        At variance, if `dynamic` is set to `False` the `example` metadata will only be
-        added to the `test_job` and not to the generated Jobs.
+        >>> test_job.update_metadata(
+        ...     {"material_id": 42},
+        ...     callback_filter=lambda job: isinstance(job.maker, SomeMaker)
+        ... )
+
+        At variance, if `dynamic` is set to `False` the metadata will only be
+        added to the filtered Jobs and not to any generated Jobs.
         """
         from jobflow.utils.dict_mods import apply_mod
 
@@ -981,6 +990,7 @@ class Job(MSONable):
                 "name_filter": name_filter,
                 "function_filter": function_filter,
                 "dict_mod": dict_mod,
+                "callback_filter": callback_filter,
             }
             self.metadata_updates.append(dict_input)
 
@@ -988,13 +998,15 @@ class Job(MSONable):
         function_filter = getattr(function_filter, "__wrapped__", function_filter)
         function = getattr(self.function, "__wrapped__", self.function)
 
-        # if function_filter is not None and function_filter != self.function:
         if function_filter is not None and function_filter != function:
             return
 
         if name_filter is not None and (
             self.name is None or name_filter not in self.name
         ):
+            return
+
+        if callback_filter(self) is False:
             return
 
         # if we get to here then we pass all the filters

--- a/src/jobflow/managers/local.py
+++ b/src/jobflow/managers/local.py
@@ -46,7 +46,7 @@ def run_locally(
         Raise an error if the flow was not executed successfully.
     allow_external_references : bool
         If False all the references to other outputs should be from other Jobs
-        of the Flow.
+        of the same Flow.
     raise_immediately : bool
         If True, raise an exception immediately if a job fails. If False, continue
         running the flow and only raise an exception at the end if the flow did not

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1083,39 +1083,6 @@ def test_flow_update_metadata_dynamic(memory_jobstore):
     assert outer_flow[0].metadata["nested_dynamic"] == "nested_value"
 
 
-@pytest.mark.skip(reason="figure out how we want to implement excludin Flows/Jobs")
-def test_flow_update_metadata_nested_flows():
-    from jobflow import Flow, Job
-
-    inner_job = Job(lambda x: x, name="inner_job")
-    inner_flow = Flow([inner_job], name="inner_flow")
-    outer_flow = Flow([inner_flow], name="outer_flow")
-
-    # Update metadata on all levels
-    outer_flow.update_metadata({"level": "outer"})
-
-    assert outer_flow.metadata["level"] == "outer"
-    assert inner_flow.metadata["level"] == "outer"
-    assert inner_job.metadata["level"] == "outer"
-
-    # Test update_metadata where no flow or job matches
-    outer_flow.update_metadata({"inner_only": "value"}, name_filter="inner_flow")
-    # should not apply to outer since name_filter does not match
-    assert "inner_only" not in outer_flow.metadata
-    # should apply to inner flow either since target is flow (i.e. self for the
-    # outer flow)
-    assert "inner_only" not in inner_flow.metadata
-    # should not apply to inner job for both above reasons
-    assert "inner_only" not in inner_job.metadata
-
-    # Update metadata only on inner flow (same as above but with target="both")
-    outer_flow.update_metadata({"inner_only": "value"}, name_filter="inner_flow")
-    assert "inner_only" not in outer_flow.metadata
-    # SHOULD now apply to inner flow
-    assert inner_flow.metadata["inner_only"] == "value"
-    assert "inner_only" not in inner_job.metadata
-
-
 def test_flow_metadata_serialization():
     import json
 

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -842,6 +842,221 @@ def test_update_metadata():
     assert flow[1].metadata["b"] == 8
 
 
+def test_flow_metadata_initialization():
+    from jobflow import Flow
+
+    # Test initialization with no metadata
+    flow = Flow([])
+    assert flow.metadata == {}
+
+    # Test initialization with metadata
+    metadata = {"key": "value"}
+    flow = Flow([], metadata=metadata)
+    # Test that metadata is the same object (not a copy, a reference)
+    assert flow.metadata is metadata
+    metadata["new_key"] = "new_value"
+    assert flow.metadata["new_key"] == "new_value"
+
+    # Test that modifying flow's metadata affects the original dictionary
+    flow.metadata["flow_key"] = "flow_value"
+    assert metadata["flow_key"] == "flow_value"
+
+
+def test_flow_update_metadata():
+    from jobflow import Flow, Job
+
+    job1 = Job(lambda x: x, name="job1")
+    job2 = Job(lambda x: x, name="job2")
+    flow = Flow([job1, job2], metadata={"initial": "value"})
+
+    # Test updating only flow metadata
+    flow.update_metadata({"flow_key": "flow_value"}, target="flow")
+    assert flow.metadata == {"initial": "value", "flow_key": "flow_value"}
+    assert "flow_key" not in job1.metadata
+    assert "flow_key" not in job2.metadata
+
+    # Test updating only jobs metadata
+    flow.update_metadata({"job_key": "job_value"}, target="jobs")
+    assert "job_key" not in flow.metadata
+    assert job1.metadata == {"job_key": "job_value"}
+    assert job2.metadata == {"job_key": "job_value"}
+
+    # Test updating both flow and jobs metadata
+    flow.update_metadata({"both_key": "both_value"}, target="both")
+    assert flow.metadata == {
+        "initial": "value",
+        "flow_key": "flow_value",
+        "both_key": "both_value",
+    }
+    assert job1.metadata == {"job_key": "job_value", "both_key": "both_value"}
+    assert job2.metadata == {"job_key": "job_value", "both_key": "both_value"}
+
+
+def test_flow_update_metadata_with_filters():
+    from jobflow import Flow, Job
+
+    job1 = Job(lambda x: x, name="job1")
+    job2 = Job(lambda x: x, name="job2")
+    flow = Flow([job1, job2])
+
+    # Test name filter
+    flow.update_metadata({"filtered": "value"}, name_filter="job1", target="jobs")
+    assert "filtered" in job1.metadata
+    assert "filtered" not in job2.metadata
+
+    # Test function filter
+    def filter_func(x):
+        return x
+
+    job3 = Job(filter_func, name="job3")
+    flow.add_jobs(job3)
+    flow.update_metadata(
+        {"func_filtered": "value"}, function_filter=filter_func, target="jobs"
+    )
+    assert "func_filtered" in job3.metadata
+    assert "func_filtered" not in job1.metadata
+    assert "func_filtered" not in job2.metadata
+
+
+def test_flow_update_metadata_dict_mod():
+    from jobflow import Flow, Job
+
+    job = Job(lambda x: x, name="job", metadata={"count": 1})
+    flow = Flow([job], metadata={"count": 1})
+
+    # Test dict_mod on flow
+    flow.update_metadata({"_inc": {"count": 1}}, target="flow", dict_mod=True)
+    assert flow.metadata["count"] == 2
+
+    # Test dict_mod on jobs
+    flow.update_metadata({"_inc": {"count": 1}}, target="jobs", dict_mod=True)
+    assert job.metadata["count"] == 2
+
+
+def test_flow_update_metadata_dynamic(memory_jobstore):
+    from dataclasses import dataclass
+
+    from jobflow import Flow, Job, Maker, Response, job
+
+    @dataclass
+    class TestMaker(Maker):
+        name: str = "test_maker"
+
+        @job
+        def make(self):
+            return Job(self.inner_job, name="dynamic_job")
+
+        def inner_job(self):
+            return Response()
+
+    @job
+    def use_maker(maker):
+        return Response(replace=maker.make())
+
+    maker = TestMaker()
+    initial_job = use_maker(maker)
+    flow = Flow([initial_job])
+
+    # Test dynamic updates
+    flow.update_metadata({"dynamic": "value"}, target="both", dynamic=True)
+
+    # Run the flow to generate the dynamic job
+    from jobflow.managers.local import run_locally
+
+    run_locally(flow, store=memory_jobstore)
+
+    # Check that the dynamic job has the metadata
+    assert "dynamic" in flow[0].metadata
+    assert flow[0].metadata["dynamic"] == "value"
+
+    # Check that the metadata update is stored in the job's metadata_updates
+    assert len(flow[0].metadata_updates) > 0
+    assert any(
+        update["update"].get("dynamic") == "value"
+        for update in flow[0].metadata_updates
+    )
+
+    # Test nested flow
+    @job
+    def create_nested_flow(maker):
+        nested_job = maker.make()
+        return Response(replace=Flow([nested_job]))
+
+    nested_initial_job = create_nested_flow(maker)
+    outer_flow = Flow([nested_initial_job])
+
+    outer_flow.update_metadata(
+        {"nested_dynamic": "nested_value"}, target="both", dynamic=True
+    )
+
+    run_locally(outer_flow, store=memory_jobstore)
+
+    # Check that the nested dynamic job has the metadata
+    assert "nested_dynamic" in outer_flow[0].metadata
+    assert outer_flow[0].metadata["nested_dynamic"] == "nested_value"
+
+    # Check that the metadata update is stored in the nested job's metadata_updates
+    assert len(outer_flow[0].metadata_updates) > 0
+    assert any(
+        update["update"].get("nested_dynamic") == "nested_value"
+        for update in outer_flow[0].metadata_updates
+    )
+
+    # Verify that the metadata was passed to the innermost job
+    assert "nested_dynamic" in outer_flow[0].metadata
+    assert outer_flow[0].metadata["nested_dynamic"] == "nested_value"
+
+
+def test_flow_update_metadata_nested_flows():
+    from jobflow import Flow, Job
+
+    inner_job = Job(lambda x: x, name="inner_job")
+    inner_flow = Flow([inner_job], name="inner_flow")
+    outer_flow = Flow([inner_flow], name="outer_flow")
+
+    # Update metadata on all levels
+    outer_flow.update_metadata({"level": "outer"}, target="both")
+
+    assert outer_flow.metadata["level"] == "outer"
+    assert inner_flow.metadata["level"] == "outer"
+    assert inner_job.metadata["level"] == "outer"
+
+    # Test update_metadata where no flow or job matches
+    outer_flow.update_metadata(
+        {"inner_only": "value"}, name_filter="inner_flow", target="flow"
+    )
+    # should not apply to outer since name_filter does not match
+    assert "inner_only" not in outer_flow.metadata
+    # should apply to inner flow either since target is flow (i.e. self for the
+    # outer flow)
+    assert "inner_only" not in inner_flow.metadata
+    # should not apply to inner job for both above reasons
+    assert "inner_only" not in inner_job.metadata
+
+    # Update metadata only on inner flow (same as above but with target="both")
+    outer_flow.update_metadata(
+        {"inner_only": "value"}, name_filter="inner_flow", target="both"
+    )
+    assert "inner_only" not in outer_flow.metadata
+    # SHOULD now apply to inner flow
+    assert inner_flow.metadata["inner_only"] == "value"
+    assert "inner_only" not in inner_job.metadata
+
+
+def test_flow_metadata_serialization():
+    import json
+
+    from monty.json import MontyDecoder, MontyEncoder
+
+    from jobflow import Flow
+
+    flow = Flow([], metadata={"key": "value"})
+    encoded = json.dumps(flow, cls=MontyEncoder)
+    decoded = json.loads(encoded, cls=MontyDecoder)
+
+    assert decoded.metadata == flow.metadata
+
+
 def test_update_config():
     from jobflow import JobConfig
 


### PR DESCRIPTION
`Flow.update_metadata` is now much more similar to and has reached feature parity with `Job.update_metadata`:

https://github.com/materialsproject/jobflow/blob/367836b0d51a89fa58a9d685c4cdb9fc7f806c01/src/jobflow/core/job.py#L922-L930