### PR TITLE
Change default callback_filter in update_metadata

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -617,7 +617,7 @@ class Flow(MSONable):
         function_filter: Callable = None,
         dict_mod: bool = False,
         dynamic: bool = True,
-        callback_filter: Callable[[Flow | Job], bool] = lambda _: True,
+        callback_filter: Callable[[Flow | Job], bool] | None = None,
     ):
         """
         Update the metadata of the Flow and/or its Jobs.
@@ -681,7 +681,7 @@ class Flow(MSONable):
                 callback_filter=callback_filter,
             )
 
-        if callback_filter(self) is False:
+        if callback_filter is not None and callback_filter(self) is False:
             return
 
         if dict_mod:

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -926,7 +926,7 @@ class Job(MSONable):
         function_filter: Callable = None,
         dict_mod: bool = False,
         dynamic: bool = True,
-        callback_filter: Callable[[jobflow.Flow | Job], bool] = lambda _: True,
+        callback_filter: Callable[[jobflow.Flow | Job], bool] | None = None,
     ):
         """
         Update the metadata of the job.
@@ -1006,7 +1006,7 @@ class Job(MSONable):
         ):
             return
 
-        if callback_filter(self) is False:
+        if callback_filter is not None and callback_filter(self) is False:
             return
 
         # if we get to here then we pass all the filters

--- a/src/jobflow/utils/uuid.py
+++ b/src/jobflow/utils/uuid.py
@@ -4,7 +4,10 @@ from monty.dev import deprecated
 
 
 @deprecated(
-    message="The UUID system will be replaced with a UID that contains both the UUID and ULID."
+    message=(
+        "The UUID system will be replaced with a UID that "
+        "contains both the UUID and ULID."
+    )
 )
 def suuid() -> str:
     """

--- a/src/jobflow/utils/uuid.py
+++ b/src/jobflow/utils/uuid.py
@@ -4,7 +4,7 @@ from monty.dev import deprecated
 
 
 @deprecated(
-    message="The UUID system will be replace with UID that contains both UUID and ULID."
+    message="The UUID system will be replaced with a UID that contains both the UUID and ULID."
 )
 def suuid() -> str:
     """


### PR DESCRIPTION
Changing the default value of `callback_filter` in the `update_metadata` function of both `Job` and `Flow` from a lambda to `None`. Having its default value be a lamdba function means that it cannot be round-trip de-/serialized:
```
from monty.json import MontyEncoder, MontyDecoder

f = lambda _ : True
encoded = MontyEncoder().encode(f)
print(encoded)
>>> '{"@module": "__main__", "@callable": "<lambda>", "@bound": null}'
decoded = MontyDecoder().decode(encoded)
print(decoded)
>>> {'@module': '__main__', '@callable': '<lambda>', '@bound': None}
```
This causes issues in fireworks with the newest release of jobflow. Linking relevant discussion [here](https://github.com/materialsproject/jobflow/pull/679#discussion_r1866290870) and tagging @janosh  and @utf for thoughts

Because lambda's aren't pickle-able without something like dill, writing a `callback_filter` as an importable function might be the only option for fireworks / jobflow users