### PR TITLE
schema -> model_json_schema

### DIFF
--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -513,7 +513,7 @@ def validate_schema_access(
         the bool is ``True`` if the schema access was valid.
         The BaseModel class associated with the item, if any.
     """
-    schema_dict = schema.schema()
+    schema_dict = schema.model_json_schema()
     if item not in schema_dict["properties"]:
         raise AttributeError(f"{schema.__name__} does not have attribute '{item}'.")
 


### PR DESCRIPTION
## 

The following warning shows is cause by one a single line. 

```
The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```

This PR fixes that line according to the message.