### PR TITLE
Allow to give a save path directly

### DIFF
--- a/src/jobflow/core/store.py
+++ b/src/jobflow/core/store.py
@@ -51,7 +51,7 @@ class JobStore(Store):
         Which items to save in additional stores when uploading documents. Given as a
         mapping of ``{store name: store_type}`` where ``store_type`` can be a dictionary
         key (string or enum), an :obj:`.MSONable` class, or a list of keys/classes.
-        If the list of keys/classes itself contains a list, this will be treated
+        If the list of keys/classes itself contains a list/tuple, this will be treated
         as the path to the save key. Can be used if a key is duplicate in the output
         and only a single occurrence shall be put in the additional store.
     load
@@ -315,8 +315,8 @@ class JobStore(Store):
                 locations = []
                 for store_name, store_save in save_keys.items():
                     for save_key in store_save:
-                        if isinstance(save_key, list):
-                            locations.append(save_key)
+                        if isinstance(save_key, list | tuple):
+                            locations.append(list(save_key))
                         else:
                             locations.extend(find_key(doc, save_key, include_end=True))
 


### PR DESCRIPTION
I have a use case where I propagate a large dictionary with many sub-dictionaries and many keys to the output of a `job`. I don't have full control over this dictionary as it is part of the user input. I use the addtional stores feature to store large parts of my output into additional stores. Now it could happen by chance that one of my additional store keys matches with one of the keys in the user-provided dictionary. Than this would be put into the additional store as well, which is not what I want.

A simple example showing this would be:

```python
from jobflow import job, run_locally, JobStore
from maggma.stores import MemoryStore

store = JobStore(MemoryStore(), additional_stores={"data": MemoryStore()})

@job(data=["ab"])
def partial_data():
    return {"xyz": {"ab": 1}, "cd": 4, "xml": {"ab": 3}}

partial_job = partial_data()
run_locally(partial_job, store=store)
print(store.query_one({"uuid": partial_job.uuid})["output"])
```

You will see two `blob_uuids` in the output. But I only want a single one.

The option to do this I propose is to give the full path directly as a list:

```python
@job(data=[["output", "xyz", "ab"]])
def partial_data():
    return {"xyz": {"ab": 1}, "cd": 4, "xml": {"ab": 3}}

partial_job = partial_data()
run_locally(partial_job, store=store)
print(store.query_one({"uuid": partial_job.uuid})["output"])
```

Now only the given path is put into the additional store and the other one not.

### TODO

- Should the `output` part in the list be omitted and prepended automatically?
- One could think about doing something similar for the `load` procedure.