### PR TITLE
getitem for Job delegates to its output

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -389,6 +389,24 @@ class Job(MSONable):
         name, uuid = self.name, self.uuid
         return f"Job({name=}, {uuid=})"
 
+    def __getitem__(self, key: Any) -> OutputReference:
+        """
+        Get the corresponding `OutputReference` for the `Job`.
+
+        This is for when it is indexed like a dictionary or list.
+
+        Parameters
+        ----------
+        key
+            The index/key.
+
+        Returns
+        -------
+        OutputReference
+            The equivalent of `Job.output[k]`
+        """
+        return self.output[key]
+
     def __contains__(self, item: Hashable) -> bool:
         """
         Check if the job contains a reference to a given UUID.

--- a/tests/core/test_flow.py
+++ b/tests/core/test_flow.py
@@ -1353,3 +1353,23 @@ def test_flow_repr():
     assert len(lines) == len(flow_repr)
     for expected, line in zip(lines, flow_repr):
         assert line.startswith(expected), f"{line=} doesn't start with {expected=}"
+
+
+def test_get_item():
+    from jobflow import Flow, job, run_locally
+
+    @job
+    def make_str(s):
+        return {"hello": s}
+
+    @job
+    def capitalize(s):
+        return s.upper()
+
+    job1 = make_str("world")
+    job2 = capitalize(job1["hello"])
+
+    flow = Flow([job1, job2])
+
+    responses = run_locally(flow, ensure_success=True)
+    assert responses[job2.uuid][1].output == "WORLD"


### PR DESCRIPTION
## Summary

This is essentially trying to resurrect the idea of `__getitem__` access to a `Job` returning the item from its `.output`, as in a [previous PR](https://github.com/materialsproject/jobflow/pull/450), but limited in scope to avoid breaking changes.

A use-case for this (included here as a test) is:
```
    @job
    def make_str(s):
        return {"hello": s}

    @job
    def capitalize(s):
        return s.upper()

    job1 = make_str("world")
    job2 = capitalize(job1["hello"])  # <---- instead of `job1.output["hello"]`

    flow = Flow([job1, job2])
```

### Context

While working with our package that uses `jobflow`, `prefect`, `parsl` and other workflow engines under the hood, we've recognized that flows are expressed succinctly as lookups on jobs:
```
    @job
    def greetings(s):
        return {"hello": f"Hello {s}", "bye": f"Goodbye {s}"}

    @job
    def upper(s):
        return s.upper()

    @flow
    def greet(s):
        job1 = greetings(s)
        job2 = upper(job1["hello"])
        return job2
 ```
 
While the `@flow` decorator is a [parallel effort](https://github.com/materialsproject/jobflow/pull/815) that we hope can be merged in soon, this PR focuses only on the `getitem` part.

The [existing PR](https://github.com/materialsproject/jobflow/pull/450) on this from a couple of years ago was also trying to integrate attribute access to jobs and flows, which is a more overreaching change, and calls for more internal refactoring than what we feel might be needed. For example, one suggested change there:
```
def __getattr__(self, name: str) -> OutputReference:
    if attr := getattr(self.output, name, None):
        return attr
    raise AttributeError(f"{type(self).__name__} has no attribute {name!r}")
```

would necessitate that all current and future attributes of `Job`s and `OutputReference`s be non-overlapping, which might be more trouble for development than is worth. A dict-lookup should not have the same disruptive effect from the point of view of the codebase, but will provide a useful shortcut for flow creation.

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply
`pip install pre-commit` and then `pre-commit install` and a check will be run
prior to allowing commits.
