### PR TITLE
A possible issue with not deepcopying job kwargs

### DIFF
--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -1418,7 +1418,8 @@ def test_job_magic_methods():
 
 
 @pytest.mark.xfail(
-    reason="Mutating one job's config mutates all others created by that decorator."
+    reason="Mutating one job's config mutates all others created by that decorator.",
+    strict=True,
 )
 def test_job_decorator_config_shared():
     from jobflow import JobConfig, job

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -1415,3 +1415,30 @@ def test_job_magic_methods():
 
     # test __hash__
     assert hash(job1) != hash(job2) != hash(job3)
+
+
+@pytest.mark.xfail(
+    reason="Mutating one job's config mutates all others created by that decorator."
+)
+def test_job_decorator_config_shared():
+    from jobflow import JobConfig, job
+
+    config = JobConfig(manager_config={"key": "original"})
+
+    @job(config=config)
+    def add_configured(a, b):
+        return a + b
+
+    job1 = add_configured(1, 3)
+    job2 = add_configured(2, 3)
+
+    assert job1.config.manager_config == {"key": "original"}
+    assert job2.config.manager_config == {"key": "original"}
+
+    job1.config.manager_config["key"] = "changed"
+
+    # job2 should still have the original value.
+    assert job2.config.manager_config == {"key": "original"}, (
+        f"Expected job2.config.manager_config to be {{'key': 'original'}}, "
+        f"but got {job2.config.manager_config!r} — shared instance bug confirmed."
+    )


### PR DESCRIPTION
As we discovered when working towards another [PR](https://github.com/materialsproject/jobflow/pull/856), mutating one job's config mutates all others created by that decorator. This is because the `@job` decorator keeps a reference to `job_kwargs` instead of deep-copying it. This may or may not be an issue, and may just need explicit documentation.

This PR introduces an `xfail` test to demonstrate this behavior. The solution suggested by @gpetretto which should solve this is:

```
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -184,6 +184,7 @@ def job(
     --------
     Job, .Flow, .Response
     """
+    from copy import deepcopy

     def decorator(func):
         from functools import wraps
@@ -214,7 +215,7 @@ def job(
                         args = args[1:]

             return Job(
-                function=f, function_args=args, function_kwargs=kwargs, **job_kwargs
+                function=f, function_args=args, function_kwargs=kwargs, **deepcopy(job_kwargs)
             )
```