### PR TITLE
implement local version of lenient_issubclass

### DIFF
--- a/src/jobflow/core/reference.py
+++ b/src/jobflow/core/reference.py
@@ -8,9 +8,9 @@ from typing import Any
 
 from monty.json import MontyDecoder, MontyEncoder, MSONable, jsanitize
 from pydantic import BaseModel
-from pydantic.v1.utils import lenient_issubclass
 
 from jobflow.utils.enum import ValueEnum
+from jobflow.utils.types import lenient_issubclass
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence

--- a/src/jobflow/utils/types.py
+++ b/src/jobflow/utils/types.py
@@ -1,0 +1,30 @@
+"""Utilities for types."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def lenient_issubclass(cls: Any, class_or_tuple: Any) -> bool:
+    """
+    Check if a class is a subclass of another class.
+
+    Partially inspired by pydantic.v1.utils.lenient_issubclass.
+    TypeError is not raised if the standard issublass fails.
+
+    Parameters
+    ----------
+    cls
+        The class to check.
+    class_or_tuple
+        The potential parent class of the class to check.
+
+    Returns
+    -------
+    bool
+        True if the class is a subclass of the target class.
+    """
+    try:
+        return isinstance(cls, type) and issubclass(cls, class_or_tuple)
+    except TypeError:
+        return False

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -1,0 +1,17 @@
+def test_lenient_issubclass():
+    from collections.abc import Mapping
+
+    from pydantic import BaseModel
+
+    from jobflow.core.schemas import JobStoreDocument
+    from jobflow.utils.types import lenient_issubclass
+
+    assert lenient_issubclass(int, int)
+    assert not lenient_issubclass(str, int)
+    assert lenient_issubclass(JobStoreDocument, BaseModel)
+
+    # these cases will raise errors using issubclass
+    assert not lenient_issubclass("test", str)
+    assert not lenient_issubclass(list[str], Mapping)
+    assert not lenient_issubclass("test", BaseModel)
+    assert not lenient_issubclass(str, "not_a_class")


### PR DESCRIPTION
Following a report from @FabiPi3, the current version of pydantic (2.12.5) raises a warning that the pydantic.v1 module is not compatible with python 3.14 or later. While this has apparently been fixed in pydantic and the warning will be gone in the next release, support for the pydantic.v1 will likely be dropped in v3: https://github.com/pydantic/pydantic/issues/10033. 
I think it is worth getting rid of that import right away, considering that the usage of that module is minimal in jobflow.

The implementation is slightly different from the original (https://github.com/pydantic/pydantic/blob/8ba0d00782cc453ab9542f8932ef2b2a47614594/pydantic/v1/utils.py#L181) since I think that we don't want the `lenient_issuclass` to ever raise an error.