### PR TITLE
fix job_kwargs

### DIFF
--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -186,6 +186,7 @@ def job(
     """
 
     def decorator(func):
+        from copy import deepcopy
         from functools import wraps
 
         # unwrap staticmethod or classmethod decorators
@@ -214,7 +215,10 @@ def job(
                         args = args[1:]
 
             return Job(
-                function=f, function_args=args, function_kwargs=kwargs, **job_kwargs
+                function=f,
+                function_args=args,
+                function_kwargs=kwargs,
+                **deepcopy(job_kwargs),
             )
 
         get_job.original = func

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -1421,10 +1421,6 @@ def test_job_magic_methods():
     assert hash(job1) != hash(job2) != hash(job3)
 
 
-@pytest.mark.xfail(
-    reason="Mutating one job's config mutates all others created by that decorator.",
-    strict=True,
-)
 def test_job_decorator_config_shared():
     from jobflow import JobConfig, job
 


### PR DESCRIPTION
As discussed in #860 and in #856, the `@job` decorator keeps a reference to the input `job_kwargs` and this could lead to inconsistencies if one of the arguments is modified in place. 
This PR implements the proposed fix, which consists in the deepcopy of the `job_kwargs`. Of course there would be a slow down if many jobs with a custom JobConfig are created when submitting a flow. I am not sure if there could be any better solution that avoids it.