### PR TITLE
Normalize flow outputs and retain dynamic subflow jobs

### DIFF
--- a/src/jobflow/core/flow.py
+++ b/src/jobflow/core/flow.py
@@ -931,6 +931,22 @@ def get_flow(
     return flow
 
 
+def _normalize_flow_output(value):
+    """Replace Jobs and Flows in nested containers with their outputs."""
+    if isinstance(value, (jobflow.Job, jobflow.Flow)):
+        return value.output
+    if isinstance(value, list):
+        return [_normalize_flow_output(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_normalize_flow_output(item) for item in value)
+    if isinstance(value, dict):
+        return {
+            _normalize_flow_output(key): _normalize_flow_output(item)
+            for key, item in value.items()
+        }
+    return value
+
+
 class DecoratedFlow(Flow):
     """A DecoratedFlow is a Flow that is returned on using the @flow decorator."""
 
@@ -973,7 +989,7 @@ class DecoratedFlow(Flow):
                 f"of your @flow decorated function.",
                 stacklevel=2,
             )
-            output = output.output
+        output = _normalize_flow_output(output)
 
         super().__init__(name=name, jobs=children_list, output=output)
 

--- a/src/jobflow/core/job.py
+++ b/src/jobflow/core/job.py
@@ -604,7 +604,12 @@ class Job(MSONable):
         from datetime import datetime
 
         from jobflow import CURRENT_JOB
-        from jobflow.core.flow import get_flow
+        from jobflow.core.flow import (
+            Flow,
+            _normalize_flow_output,
+            flow_build_context,
+            get_flow,
+        )
         from jobflow.core.schemas import JobStoreDocument
 
         index_str = f", {self.index}" if self.index != 1 else ""
@@ -626,7 +631,13 @@ class Job(MSONable):
         if bound is not None and not isinstance(bound, types.ModuleType):
             function = types.MethodType(function, bound)
 
-        response = function(*self.function_args, **self.function_kwargs)
+        children = []
+        with flow_build_context(children):
+            response = function(*self.function_args, **self.function_kwargs)
+
+        children = [child for child in children if child.host is None]
+        if children and not isinstance(response, Response):
+            response = Flow(jobs=children, output=_normalize_flow_output(response))
         response = Response.from_job_returns(
             response, self.output_schema, job_dir=job_dir
         )

--- a/tests/core/test_flow_decorator.py
+++ b/tests/core/test_flow_decorator.py
@@ -159,6 +159,19 @@ def test_flow_returns_output_reference():
     assert result[flow1.output.uuid][1].output == 7
 
 
+def test_flow_normalizes_nested_job_outputs():
+    """Test Jobs nested in decorated flow outputs resolve to references."""
+    from jobflow import flow
+
+    @flow
+    def my_flow():
+        return {"nested": (add(1, 2),)}
+
+    flow1 = my_flow()
+
+    assert flow1.output == {"nested": (flow1.jobs[0].output,)}
+
+
 def test_flow_returns_list():
     """Test that a flow that returns a list of OutputReferences
     can be created and run."""

--- a/tests/core/test_job.py
+++ b/tests/core/test_job.py
@@ -83,7 +83,6 @@ def test_job_run(capsys, memory_jobstore, memory_data_jobstore):
     response = test_job.run(memory_jobstore)
     assert capsys.readouterr().out == "I am a job\n"
     assert isinstance(response, Response)
-
     # test run with outputs
     test_job = Job(add, function_args=(1,), function_kwargs={"b": 2})
     response = test_job.run(memory_jobstore)
@@ -1447,3 +1446,23 @@ def test_job_decorator_config_shared():
         f"Expected job2.config.manager_config to be {{'key': 'original'}}, "
         f"but got {job2.config.manager_config!r} — shared instance bug confirmed."
     )
+
+
+def test_job_collects_dynamic_subflow(memory_jobstore):
+    """Test a job retains every job created by a returned dynamic subflow."""
+    from jobflow import Flow, job
+
+    @job
+    def add_job(a, b):
+        return a + b
+
+    @job
+    def dynamic_subflow():
+        first = add_job(1, 2)
+        return add_job(first.output, 3)
+
+    response = dynamic_subflow().run(memory_jobstore)
+
+    assert isinstance(response.replace, Flow)
+    assert len(response.replace) == 3
+    assert response.replace.output.uuid == response.replace[-2].uuid


### PR DESCRIPTION
## Summary

- Normalize nested `Job` and `Flow` values returned by `@flow` into output references.
- Collect all jobs created while a job function executes when its return value defines a dynamic subflow.
- Preserve the full dynamic subflow as the replacement flow instead of retaining only the returned terminal job.
- Add regression tests for nested decorated-flow outputs and multi-job dynamic subflows.

## Why

Downstream workflow adapters currently need to wrap decorated flow outputs recursively and compose `@job` with `@flow` to prevent intermediate jobs in dynamic subflows from being lost. This behavior is general Jobflow composition logic and belongs upstream.

Together with #885, this allows Quantum-Accelerators/quacc#3405 to remove its Jobflow-specific normalization and subflow patches from `src/quacc/wflow_tools/decorators.py`.

## Additional dependencies introduced

None.

## Validation

- `PYTHONPATH=src python -m pytest tests/core/test_flow_decorator.py tests/core/test_job.py -q` — 39 passed, 1 xfailed
- `python -m ruff check --ignore PLR0917 src/jobflow/core/flow.py src/jobflow/core/job.py tests/core/test_flow_decorator.py tests/core/test_job.py` — passed
- `git diff --check` — passed

## Checklist

- [x] Tests have been added for the new behavior.
- [x] Focused linting and tests pass.
